### PR TITLE
buffers.pl 5.0: fix cropping non-latin buffer names

### DIFF
--- a/perl/buffers.pl
+++ b/perl/buffers.pl
@@ -20,6 +20,8 @@
 #
 # History:
 #
+# 2014-12-12
+#     v5.0: fix cropping non-latin buffer names
 # 2014-08-29, Patrick Steinhardt <ps@pks.im>:
 #     v4.9: add support for specifying custom buffer names
 # 2014-07-19, Sebastien Helleu <flashcode@flashtux.org>:
@@ -162,7 +164,7 @@ use strict;
 use Encode qw( decode encode );
 # -----------------------------[ internal ]-------------------------------------
 my $SCRIPT_NAME = "buffers";
-my $SCRIPT_VERSION = "4.9";
+my $SCRIPT_VERSION = "5.0";
 
 my $BUFFERS_CONFIG_FILE_NAME = "buffers";
 my $buffers_config_file;
@@ -1386,7 +1388,8 @@ sub build_buffers
 
         if (weechat::config_integer($options{"name_size_max"}) >= 1)                # check max_size of buffer name
         {
-            $str .= encode("UTF-8", substr(decode("UTF-8", $name), 0, weechat::config_integer($options{"name_size_max"})));
+            $name = decode("UTF-8", $name);
+            $str .= encode("UTF-8", substr($name, 0, weechat::config_integer($options{"name_size_max"})));
             $str .= weechat::color(weechat::config_color( $options{"color_number_char"})).weechat::config_string($options{"name_crop_suffix"}) if (length($name) > weechat::config_integer($options{"name_size_max"}));
             $str .= add_inactive_parentless($buffer->{"type"}, $buffer->{"nicks_count"});
             $str .= add_hotlist_count($buffer->{"pointer"}, %hotlist);


### PR DESCRIPTION
currently the thing crops bytes, not characters
