### PR TITLE
Use last index to handle all buffer nesting levels

### DIFF
--- a/perl/hl_here.pl
+++ b/perl/hl_here.pl
@@ -25,7 +25,7 @@ sub highlight_everywhere {
     my @chan = split(/\./, $bfname);
 
     if($hl == 1 && $buffer ne weechat::current_buffer()) {
-        weechat::print_date_tags(weechat::current_buffer(), 0, 'no_log', $chan[1]."\t".'<'.$prefix.weechat::color('default').'> '.$msg);
+        weechat::print_date_tags(weechat::current_buffer(), 0, 'no_log', $chan[-1]."\t".'<'.$prefix.weechat::color('default').'> '.$msg);
     }
 
     return weechat::WEECHAT_RC_OK;

--- a/perl/hl_here.pl
+++ b/perl/hl_here.pl
@@ -14,10 +14,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+# History:
+#
+# 2015-06-29, Matthew Cox <matthewcpcox@gmail.com>:
+#     v0.2: fix for all buffer nesting levels
+# 2013-10-19, Sascha Ohms <sasch9r@gmail.com>:
+#     v0.1: script creation
+#
 
 use strict;
 
-weechat::register('hl_here', 'Sascha Ohms', '0.1', 'GPL3', 'Show any highlights in the active buffer', '', '');
+weechat::register('hl_here', 'Sascha Ohms', '0.2', 'GPL3', 'Show any highlights in the active buffer', '', '');
 
 sub highlight_everywhere {
     my ($data, $buffer, $date, $tags, $disp, $hl, $prefix, $msg) = @_;


### PR DESCRIPTION
This change makes the script work without errors no matter the nesting level of the buffer you are highlighted in.

My actual use-case for this is with the weetweet.py script, which adds a server-level 'twitter' buffer.
Any time I get @mentioned on Twitter currently I get an error in the weechat buffer due to the invalid indexing of $chan.