### PR TITLE
autojoin.py: Support storing the channels list as secure data

### DIFF
--- a/python/autojoin.py
+++ b/python/autojoin.py
@@ -43,6 +43,9 @@
 # 2014-05-22, Nathaniel Wesley Filardo <PADEBR2M2JIQN02N9OO5JM0CTN8K689P@cmx.ietfng.org>
 #     version 0.2.5: Fix keyed channel support
 #
+# 2016-01-13, The fox in the shell <KellerFuchs@hashbang.sh>
+#     version 0.2.6: Support keeping chan list as secured data
+#
 # @TODO: add options to ignore certain buffers
 # @TODO: maybe add an option to enable autosaving on part/join messages
 
@@ -89,9 +92,7 @@ def autosave_channels_on_quit(signal, callback, callback_data):
 
     # print/execute commands
     for server, channels in items.iteritems():
-        channels = channels.rstrip(',')
-        command = "/set irc.server.%s.autojoin '%s'" % (server, channels)
-        w.command('', command)
+        process_server(server, channels)
 
     return w.WEECHAT_RC_OK
 
@@ -111,10 +112,7 @@ def autosave_channels_on_activity(signal, callback, callback_data):
         match = re.match(pattern, callback_data)
 
         if match: # check if nick is my nick. In that case: save
-            channel = match.group(2)
-            channels = channels.rstrip(',')
-            command = "/set irc.server.%s.autojoin '%s'" % (server, channels)
-            w.command('', command)
+            process_server(server, channels)
         else: # someone else: ignore
             continue
 
@@ -126,18 +124,37 @@ def autojoin_cb(data, buffer, args):
     """But I can't believe somebody would want that behaviour"""
     items = find_channels()
 
+    if args == '--run':
+        run = True
+    else:
+        run = False
+
     # print/execute commands
     for server, channels in items.iteritems():
+        process_server(server, channels, run)
+
+    return w.WEECHAT_RC_OK
+
+def process_server(server, channels, run=True):
+        option   = "irc.server.%s.autojoin" % server
         channels = channels.rstrip(',')
+        oldchans = w.config_string(w.config_get(option))
+
         if not channels: # empty channel list
-            continue
-        command = '/set irc.server.%s.autojoin %s' % (server, channels)
-        if args == '--run':
+            return
+
+        # Note: re already caches the result of regexp compilation
+        sec = re.match('^\${sec\.data\.(.*)}$', oldchans)
+        if sec:
+            secvar = sec.group(1)
+            command = "/secure set %s %s" % (secvar, channels)
+        else:
+            command = "/set irc.server.%s.autojoin '%s'" % (server, channels)
+
+        if run:
             w.command('', command)
         else:
             w.prnt('', command)
-
-    return w.WEECHAT_RC_OK
 
 def find_channels():
     """Return list of servers and channels"""


### PR DESCRIPTION
This is useful for `autojoin.py` users who do not keep logs and do not wish to leave their channels list lying around unencrypted (because they like tinfoil hats, wish to avoid potential embarassement, ...)