### PR TITLE
colorize_nicks.py 22: invalidate cached colors on hash algorithm change

### DIFF
--- a/python/colorize_nicks.py
+++ b/python/colorize_nicks.py
@@ -21,6 +21,8 @@
 #
 #
 # History:
+# 2016-05-01, Simmo Saan <simmo.saan@gmail.com>
+#   version 22: invalidate cached colors on hash algorithm change
 # 2015-07-28, xt
 #   version 21: fix problems with nicks with commas in them
 # 2015-04-19, xt
@@ -75,7 +77,7 @@ w = weechat
 
 SCRIPT_NAME    = "colorize_nicks"
 SCRIPT_AUTHOR  = "xt <xt@bash.no>"
-SCRIPT_VERSION = "21"
+SCRIPT_VERSION = "22"
 SCRIPT_LICENSE = "GPL"
 SCRIPT_DESC    = "Use the weechat nick colors in the chat area"
 
@@ -339,6 +341,7 @@ if __name__ == "__main__":
         w.hook_modifier('weechat_print', 'colorize_cb', '')
         # Hook config for changing colors
         w.hook_config('weechat.color.chat_nick_colors', 'populate_nicks', '')
+        w.hook_config('weechat.look.nick_color_hash', 'populate_nicks', '')
         # Hook for working togheter with other scripts (like colorize_lines)
         w.hook_modifier('colorize_nicks', 'colorize_cb', '')
         # Hook for modifying input


### PR DESCRIPTION
Before this change changing the hash algorithm used for random nick colors did not affect colorize_nicks, it just kept using the old colors since it caches them. This patch makes the script repopulate its colors cache when the hash algorithm changes to reflect actual nick colors.

It hooks the moved hash algorithm option in 1.5 so this only makes a difference to anyone on a fresh enough version of WeeChat. An additional hook for the old option could've been added but it's not worth keeping too much backwards compatibility.