### PR TITLE
go.py 2.3: fix fuzzy search breaking buffer number search display (closes #191)

### DIFF
--- a/python/go.py
+++ b/python/go.py
@@ -21,6 +21,8 @@
 #
 # History:
 #
+# 2017-02-25, Simmo Saan <simmo.saan@gmail.com>
+#     version 2.3: fix fuzzy search breaking buffer number search display
 # 2016-01-28, ylambda <ylambda@koalabeast.com>
 #     version 2.2: add option fuzzy_search
 # 2015-11-12, nils_2 <weechatter@arcor.de>
@@ -86,7 +88,7 @@ from __future__ import print_function
 
 SCRIPT_NAME = 'go'
 SCRIPT_AUTHOR = 'Sébastien Helleu <flashcode@flashtux.org>'
-SCRIPT_VERSION = '2.2'
+SCRIPT_VERSION = '2.3'
 SCRIPT_LICENSE = 'GPL3'
 SCRIPT_DESC = 'Quick jump to buffers'
 
@@ -406,7 +408,8 @@ def go_buffers_to_string(listbuf, pos, strinput):
                 weechat.color(weechat.config_get_plugin(
                     'color_name' + selected)),
                 buffer_name[index2:])
-        elif go_option_enabled("fuzzy_search"):
+        elif go_option_enabled("fuzzy_search") and
+             go_match_fuzzy(buffer_name.lower(), strinput):
             name = ""
             prev_index = -1
             for char in strinput.lower():


### PR DESCRIPTION
An extra fuzzy match check was added to displaying the search results to avoid buffers matched by number from being rendered using fuzzy search display methods which fail in this case due to the number not actually being present in the buffer name.