### PR TITLE
url_hint fix unexpected encoding errors

### DIFF
--- a/ruby/url_hinter.rb
+++ b/ruby/url_hinter.rb
@@ -372,6 +372,6 @@ class Line
   end
 
   def urls
-    remove_color_message.scan(/https?:\/\/[^ 　\(\)\r\n]*/).uniq
+      remove_color_message.encode("UTF-8", invalid: :replace, undef: :replace).scan(/https?:\/\/[^ 　\(\)\r\n]*/).uniq
   end
 end


### PR DESCRIPTION
when url_hinter encounters "weired" encodings in chat messages it will fail with and unexpected encoding message, this will convert "best effort" all text to UTF-8 and try to find an URL.