### PR TITLE
launcher.pl 0.7: properly fix escaping of "signal_data"

### DIFF
--- a/perl/launcher.pl
+++ b/perl/launcher.pl
@@ -22,6 +22,8 @@
 #
 # History:
 #
+# 2017-09-07, Alex Xu (Hello71) <alex_y_xu@yahoo.ca>:
+#     version 0.7: properly fix escaping of "signal_data"
 # 2017-08-29, Alex Xu (Hello71) <alex_y_xu@yahoo.ca>:
 #     version 0.6: fix escaping of "signal_data"
 # 2011-02-13, Sebastien Helleu <flashcode@flashtux.org>:
@@ -111,7 +113,7 @@ sub signal
     my $command = weechat::config_get_plugin("signal.$_[1]");
     if ($command ne "")
     {
-        $signal_data =~ s/'/'\''/g;
+        $signal_data =~ s/'/'\\''/g;
         $command =~ s/\$signal_data/'$signal_data'/g;
         system($command.$command_suffix);
     }


### PR DESCRIPTION
This time I actually tested it.