### PR TITLE
[WIP] notify.py 0.0.9 Works with weechat compiled with python3 now

### DIFF
--- a/python/notify.py
+++ b/python/notify.py
@@ -38,6 +38,7 @@
 #     version 0.0.3: added config options for icon and urgency
 # 2009-05-02, FlashCode <flashcode@flashtux.org>:
 #     version 0.0.2.1: sync with last API changes
+from __future__ import print_function
 
 # script variables
 SCRIPT_NAME = "notify"

--- a/python/notify.py
+++ b/python/notify.py
@@ -69,6 +69,7 @@ settings = {
     "notify_when_away": "off",
     "nick_separator": ": ",
     "icon": "/usr/share/pixmaps/weechat.xpm",
+    "urgency": "normal",
     "ignore_nicks_startwith": "*",
     "smart_notification": "off"
 }


### PR DESCRIPTION
Modified the notify.py script to work with python3 compiled weechat. The script still needs the python2-notify2 package but it works with weechat 2.1 compiled with python3 now. I don't know if it should be tagged as py3k-ok yet since it depends on python2 package.