### PR TITLE
Updated function used to set pointer to fallback buffer

### DIFF
--- a/perl/query_blocker.pl
+++ b/perl/query_blocker.pl
@@ -324,7 +324,7 @@ sub print_info {
         if ( $server eq "" ){
             $buf_pointer = weechat::buffer_search_main();
         }else{
-            $buf_pointer = fallback($server);
+            $buf_pointer = fallback_buffer($server);
         }
     }
     return $buf_pointer if (lc(weechat::config_get_plugin('quiet') eq "on"));


### PR DESCRIPTION
* Allow someone to query
* /query_blocker del network.nick
* /close (the query)
* Ask someone to query you again, query window will open and error is emitted to weechat core buffer

settings: https://i.imgur.com/Y54mnVW.png