### PR TITLE
auto_away.py: py3ok

### DIFF
--- a/python/auto_away.py
+++ b/python/auto_away.py
@@ -87,13 +87,15 @@
 #                         /autoaway without arguments outputs current
 #                         settings.
 #                         Code rewrite.
+#   2018-10-02 - 0.4    - Pol Van Aubel <dev@polvanaubel.com>:
+#                         Make Python3 compatible.
 
+from __future__ import print_function
 try:
     import weechat as w
-    
-except Exception:
-    print "This script must be run under WeeChat."
-    print "Get WeeChat now at: http://www.weechat.org/"
+except:
+    print("This script must be run under WeeChat.")
+    print("Get WeeChat now at: http://www.weechat.org/")
     quit()
 
 # Script Properties


### PR DESCRIPTION
Make auto_away.py py3ok.

Trivial change in code that should never be run within weechat anyway, checked rest of code for behavioural consistency. Tested under 2.2 with python 2.7.15 and under 2.3-dev with python 3.7.0.

Maybe too trivial for a version bump.