### PR TITLE
fish.py 0.9.3: fix compatibility with new Crypto

### DIFF
--- a/python/fish.py
+++ b/python/fish.py
@@ -54,7 +54,7 @@
 
 SCRIPT_NAME = "fish"
 SCRIPT_AUTHOR = "David Flatz <david@upcs.at>"
-SCRIPT_VERSION = "0.9.2"
+SCRIPT_VERSION = "0.9.3"
 SCRIPT_LICENSE = "GPL3"
 SCRIPT_DESC = "FiSH for weechat"
 CONFIG_FILE_NAME = SCRIPT_NAME
@@ -232,7 +232,9 @@ class Blowfish:
         if key:
             if len(key) > 72:
                 key = key[:72]
-            self.blowfish = Crypto.Cipher.Blowfish.new(key)
+            self.blowfish = Crypto.Cipher.Blowfish.new(
+                key, Crypto.Cipher.Blowfish.MODE_ECB
+            )
 
     def decrypt(self, data):
         return self.blowfish.decrypt(data)

--- a/python/fish.py
+++ b/python/fish.py
@@ -69,14 +69,14 @@ from os import urandom
 try:
     import weechat
 except ImportError:
-    print "This script must be run under WeeChat."
-    print "Get WeeChat now at: http://www.weechat.org/"
+    print("This script must be run under WeeChat.")
+    print("Get WeeChat now at: http://www.weechat.org/")
     import_ok = False
 
 try:
     import Crypto.Cipher.Blowfish
 except:
-    print "Python Cryptography Toolkit must be installed to use fish"
+    print("Python Cryptography Toolkit must be installed to use fish")
     import_ok = False
 
 
@@ -271,9 +271,9 @@ def blowcrypt_b64decode(s):
         for i, p in enumerate(s[6:12]):
             left |= B64.index(p) << (i * 6)
         for i in range(0,4):
-            res +=chr(((left & (0xFF << ((3 - i) * 8))) >> ((3 - i) * 8)))
+            res += chr(((left & (0xFF << ((3 - i) * 8))) >> ((3 - i) * 8)))
         for i in range(0,4):
-            res +=chr(((right & (0xFF << ((3 - i) * 8))) >> ((3 - i) * 8)))
+            res += chr(((right & (0xFF << ((3 - i) * 8))) >> ((3 - i) * 8)))
         s = s[12:]
     return res
 
@@ -333,7 +333,7 @@ p_dh1080 = int('FBE1022E23D213E8ACFA9AE8B9DFAD'
                '83EB68FA07A77AB6AD7BEB618ACF9C'
                'A2897EB28A6189EFA07AB99A8A7FA9'
                'AE299EFA7BA66DEAFEFBEFBF0B7D8B', 16)
-q_dh1080 = (p_dh1080 - 1) / 2
+q_dh1080 = (p_dh1080 - 1) // 2
 
 
 def dh1080_b64encode(s):
@@ -447,7 +447,7 @@ class DH1080Ctx:
 
         bits = 1080
         while True:
-            self.private = bytes2int(urandom(bits / 8))
+            self.private = bytes2int(urandom(bits // 8))
             self.public = pow(g_dh1080, self.private, p_dh1080)
             if 2 <= self.public <= p_dh1080 - 1 and \
                dh_validate_public(self.public, q_dh1080, p_dh1080) == 1:
@@ -486,7 +486,7 @@ def dh1080_unpack(msg, ctx):
                 raise MalformedError
 
             if not dh_validate_public(public, q_dh1080, p_dh1080):
-                #print invalidmsg
+                #print(invalidmsg)
                 pass
 
             ctx.secret = pow(public, ctx.private, p_dh1080)
@@ -505,7 +505,7 @@ def dh1080_unpack(msg, ctx):
                 raise MalformedError
 
             if not dh_validate_public(public, q_dh1080, p_dh1080):
-                #print invalidmsg
+                #print(invalidmsg)
                 pass
 
             ctx.secret = pow(public, ctx.private, p_dh1080)
@@ -538,7 +538,7 @@ def int2bytes(n):
     b = ''
     while n:
         b = chr(n % 256) + b
-        n /= 256
+        n //= 256
     return b
 
 


### PR DESCRIPTION
Fixes

```
python: stdout/stderr (fish): Traceback (most recent call last):
python: stdout/stderr (fish):   File "/home/rr-/.weechat/python/autoload/fish.py", line 703, in fish_modifier_in_privmsg_cb
python: stdout/stderr (fish):     b = Blowfish(fish_keys[targetl])
python: stdout/stderr (fish):   File "/home/rr-/.weechat/python/autoload/fish.py", line 235, in __init__
python: stdout/stderr (fish):     self.blowfish = Crypto.Cipher.Blowfish.new(key)
python: stdout/stderr (fish): TypeError: new() takes at least 2 arguments (1 given)
python: error in function "fish_modifier_in_privmsg_cb"
```