### PR TITLE
shortenurl.py 0.6.3: is.gd api call changed

### DIFF
--- a/python/shortenurl.py
+++ b/python/shortenurl.py
@@ -14,6 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # History
+# 2018-11-02, Jochen Saalfeld <privat@jochen-saalfeld.de>
+#  version 0.6.3: Fix is.gd URL pattern
+#                 (api.php is depricated)
 # 2018-07-12, Daniel Karbach <daniel.karbach@localhorst.tv>
 #  version 0.6.2: Fix is.gd URL pattern
 #                 (longurl param is appended by urlencode)
@@ -49,7 +52,7 @@ SCRIPT_VERSION = "0.6.2"
 SCRIPT_LICENSE = "GPL3"
 SCRIPT_DESC = "Shorten long incoming and outgoing URLs"
 
-ISGD = 'https://is.gd/api.php?%s'
+ISGD = 'https://is.gd/create.php?format=simple&%s'
 TINYURL = 'http://tinyurl.com/api-create.php?%s'
 
 # script options
@@ -143,7 +146,7 @@ def get_shortened_url(url):
         history = 1 if weechat.config_get_plugin('bitly_add_to_history') == 'true' else 0
         return api.shorten(url, {'history':history})
     if shortener == 'isgd':
-        url = ISGD % urlencode({'longurl': url})
+        url = ISGD % urlencode({'url': url})
     if shortener == 'tinyurl':
         url = TINYURL % urlencode({'url': url})
     try:


### PR DESCRIPTION
The api.php is depricated. So i changed it according to the
reference: https://is.gd/apishorteningreference.php

This is the current situation:

![2018-11-02_11-20](https://user-images.githubusercontent.com/6213120/47909851-602d3600-de91-11e8-945b-2c02944d0e11.png)

The change will result in the following situation:

![2018-11-02_11-22](https://user-images.githubusercontent.com/6213120/47909914-8b178a00-de91-11e8-8ba6-26df4801f275.png)
