### PR TITLE
fullwidth.py 0.1.1: Correctly handle fullwidth spaces.

### DIFF
--- a/python/fullwidth.py
+++ b/python/fullwidth.py
@@ -27,7 +27,7 @@ import weechat
 
 SCRIPT_NAME = "fullwidth"
 SCRIPT_AUTHOR = "GermainZ <germanosz@gmail.com>"
-SCRIPT_VERSION = "0.1"
+SCRIPT_VERSION = "0.1.1"
 SCRIPT_LICENSE = "GPL3"
 SCRIPT_DESC = ("Convert text to its ｆｕｌｌｗｉｄｔｈ equivalent and send it "
                "to buffer.")
@@ -50,7 +50,9 @@ def cb_fullwidth_cmd(data, buf, args):
         args = args.decode("utf-8")
     for char in list(args):
         ord_char = ord(char)
-        if ord_char >= 32 and ord_char <= 126:
+        if ord_char == 32:
+            char = unichr(12288)
+        elif ord_char > 32 and ord_char <= 126:
             char = unichr(ord_char + 65248)
         chars.append(char)
     send(buf, ''.join(chars))


### PR DESCRIPTION
From the wikipedia article [Halfwidth and fullwidth forms](https://en.wikipedia.org/wiki/Halfwidth_and_fullwidth_forms):

> U+FF00 does not correspond to a fullwidth ASCII 20 (space character), since that role is already fulfilled by U+3000 "ideographic space".

(12288 is decimal U+3000)

---

Note: According to the [contributing guidelines](https://github.com/weechat/scripts/blob/master/Contributing.adoc), I have contacted `GermainZ <germanosz@gmail.com>` as of immediately after creating this PR. Hopefully they respond soon :)

Additionally, I checked their github profile page, and they don't seem to have a personal repository for fullwidth.py (it's... not a large script), so keeping code in sync shouldn't be a problem.