### PR TITLE
buffer_autohide 0.4: Optionally keep buffers active for a given time

### DIFF
--- a/python/buffer_autohide.py
+++ b/python/buffer_autohide.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # MIT License
 #
-# Copyright (c) 2017-2018 Matthias Adamczyk
+# Copyright (c) 2017-2019 Matthias Adamczyk
+# Copyright (c) 2019 Marco Trevisan
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,6 +32,8 @@ Configuration:
     plugins.var.python.buffer_autohide.unhide_low: Unhide a buffer when a low priority message (like JOIN,
         PART, etc.) has been received (default: "off"),
     plugins.var.python.buffer_autohide.exemptions: An enumeration of buffers that should not become hidden (default: "")
+    plugins.var.python.buffer_autohide.keep_open: Keep a buffer open for a short amount of time (default: "off")
+    plugins.var.python.buffer_autohide.keep_open_timeout: Timeout in milliseconds for how long a selected buffer should be kept around (default: "60 * 1000")
 
 History:
 2017-03-19: Matthias Adamczyk <mail@notmatti.me>
@@ -39,10 +42,14 @@ History:
     version 0.2: Only skip irc.servers
 2018-12-07: Matthias Adamczyk <mail@notmatti.me>
     version 0.3: Add a functionality to define exemptions for certain buffers
+2018-12-07: Marco Trevisan <mail@3v1n0.net>
+    version 0.4: Keep buffers active for a given time before hide them again if they should
 
 https://github.com/notmatti/buffer_autohide
 """
 from __future__ import print_function
+import ast
+import operator as op
 import_ok = True
 try:
     import weechat
@@ -54,29 +61,72 @@ except ImportError:
 
 SCRIPT_NAME = "buffer_autohide"
 SCRIPT_AUTHOR = "Matthias Adamczyk <mail@notmatti.me>"
-SCRIPT_VERSION = "0.3"
+SCRIPT_VERSION = "0.4"
 SCRIPT_LICENSE = "MIT"
 SCRIPT_DESC = "Automatically hide read IRC buffers and unhide them on new activity"
 SCRIPT_COMMAND = SCRIPT_NAME
 
 DELIMITER = "|@|"
+MINIMUM_BUFFER_LIFE = 500 # How many ms are enough to consider a buffer valid
+KEEP_ALIVE_TIMEOUT = 60 * 1000 # How long a selected buffer should be kept around
+
 CURRENT_BUFFER = "0x0" # pointer string representation
+CURRENT_BUFFER_TIMER_HOOK = None # Timeout hook reference
+KEEP_ALIVE_BUFFERS = {} # {pointer_string_rep: timeout_hook}
 
 
 def config_init():
     """Add configuration options to weechat."""
+    global KEEP_ALIVE_TIMEOUT
+
     config = {
         "hide_inactive": ("off", "Hide inactive buffers"),
         "hide_private": ("off", "Hide private buffers"),
         "unhide_low": ("off",
             "Unhide a buffer when a low priority message (like JOIN, PART, etc.) has been received"),
         "exemptions": ("", "An enumeration of buffers that should not get hidden"),
+        "keep_open": ("off", "Keep a buffer open for a short amount of time"),
+        "keep_open_timeout": ("60 * 1000", "Timeout in milliseconds for how long a selected buffer should be kept around"),
     }
     for option, default_value in config.items():
         if weechat.config_get_plugin(option) == "":
             weechat.config_set_plugin(option, default_value[0])
         weechat.config_set_desc_plugin(
             option, '{} (default: "{}")'.format(default_value[1], default_value[0]))
+
+    weechat.hook_config("plugins.var.python.buffer_autohide.keep_open_timeout", "timeout_config_changed_cb", "")
+    if weechat.config_is_set_plugin("keep_open_timeout"):
+        KEEP_ALIVE_TIMEOUT = eval_expr(weechat.config_get_plugin("keep_open_timeout"))
+
+
+def eval_expr(expr):
+    """Evaluate a mathematical expression.
+
+    >>> eval_expr('2 * 6')
+    12
+    """
+    def evaluate(node):
+        # supported operators
+        operators = {ast.Add: op.add, ast.Sub: op.sub, ast.Mult: op.mul,
+                     ast.Div: op.truediv, ast.Pow: op.pow, ast.BitXor: op.xor,
+                     ast.USub: op.neg}
+        if isinstance(node, ast.Num): # <number>
+            return node.n
+        elif isinstance(node, ast.BinOp): # <left> <operator> <right>
+            return operators[type(node.op)](evaluate(node.left), evaluate(node.right))
+        elif isinstance(node, ast.UnaryOp): # <operator> <operand> e.g., -1
+            return operators[type(node.op)](evaluate(node.operand))
+        else:
+            raise TypeError(node)
+
+    return evaluate(ast.parse(expr, mode='eval').body)
+
+
+def timeout_config_changed_cb(data, option, value):
+    """Set the new keep_alive timeout upon change of the corresponding value in plugins.conf."""
+    global KEEP_ALIVE_TIMEOUT
+    KEEP_ALIVE_TIMEOUT = eval_expr(value)
+    return WEECHAT_RC_OK
 
 
 def hotlist_dict():
@@ -109,8 +159,82 @@ def hotlist_dict():
     return hotlist
 
 
-def hide_buffer_cb(data, signal, signal_data):
-    """Hide the previous IRC buffer when switching buffers.
+def on_temporary_active_buffer_timeout(buffer, remaining_calls):
+    remove_keep_alive(buffer)
+    maybe_hide_buffer(buffer)
+
+    return weechat.WEECHAT_RC_OK
+
+
+def keep_alive_buffer(buffer):
+    remove_keep_alive(buffer)
+
+    if buffer_is_hidable(buffer):
+        KEEP_ALIVE_BUFFERS[buffer] = weechat.hook_timer(KEEP_ALIVE_TIMEOUT, 0, 1,
+            "on_temporary_active_buffer_timeout", buffer)
+
+
+def remove_keep_alive(buffer):
+    global KEEP_ALIVE_BUFFERS
+
+    if buffer in KEEP_ALIVE_BUFFERS.keys():
+        weechat.unhook(KEEP_ALIVE_BUFFERS.pop(buffer))
+
+
+def switch_current_buffer():
+    """Save current buffer and ensure that it's visible, then if the
+    buffer is elegible to be hidden, we add it to the list of the buffers
+    to be hidden after a delay
+    """
+    global CURRENT_BUFFER
+    global CURRENT_BUFFER_TIMER_HOOK
+
+    previous_buffer = CURRENT_BUFFER
+    CURRENT_BUFFER = weechat.current_buffer()
+
+    if previous_buffer == CURRENT_BUFFER:
+        return
+
+    if weechat.buffer_get_integer(CURRENT_BUFFER, "hidden") == 1:
+        weechat.buffer_set(CURRENT_BUFFER, "hidden", "0")
+
+    if weechat.config_get_plugin("keep_open") != "off":
+        if CURRENT_BUFFER_TIMER_HOOK is not None:
+            weechat.unhook(CURRENT_BUFFER_TIMER_HOOK)
+            CURRENT_BUFFER_TIMER_HOOK = None
+            maybe_hide_buffer(previous_buffer)
+        else:
+            keep_alive_buffer(previous_buffer)
+
+        CURRENT_BUFFER_TIMER_HOOK = weechat.hook_timer(MINIMUM_BUFFER_LIFE, 0, 1,
+            "on_current_buffer_is_still_active_timeout", "")
+    else:
+        maybe_hide_buffer(previous_buffer)
+
+
+def on_current_buffer_is_still_active_timeout(pointer, remaining_calls):
+    global CURRENT_BUFFER_TIMER_HOOK
+    global KEEP_ALIVE_BUFFERS
+
+    CURRENT_BUFFER_TIMER_HOOK = None
+    remove_keep_alive(CURRENT_BUFFER)
+
+    return weechat.WEECHAT_RC_OK
+
+
+def switch_buffer_cb(data, signal, signal_data):
+    """
+    :param data: Pointer
+    :param signal: Signal sent by Weechat
+    :param signal_data: Data sent with signal
+    :returns: callback return value expected by Weechat.
+    """
+    switch_current_buffer()
+    return WEECHAT_RC_OK
+
+
+def buffer_is_hidable(buffer):
+    """Check if passed buffer can be hidden.
 
     If configuration option ``hide_private`` is enabled,
     private buffers will become hidden as well.
@@ -118,23 +242,21 @@ def hide_buffer_cb(data, signal, signal_data):
     If the previous buffer name matches any of the exemptions defined in ``exemptions``,
     it will not become hidden.
 
-    :param data: Pointer
-    :param signal: Signal sent by Weechat
-    :param signal_data: Data sent with signal
-    :returns: callback return value expected by Weechat.
+    :param buffer: Buffer string representation
     """
-    global CURRENT_BUFFER
+    if buffer == weechat.current_buffer():
+        return False
 
-    previous_buffer = CURRENT_BUFFER
-    CURRENT_BUFFER = weechat.current_buffer()
+    if buffer in KEEP_ALIVE_BUFFERS.keys():
+        return False
 
-    plugin = weechat.buffer_get_string(previous_buffer, "plugin")
-    full_name = weechat.buffer_get_string(previous_buffer, "full_name")
-    server = weechat.buffer_get_string(previous_buffer, "localvar_server")
-    channel = weechat.buffer_get_string(previous_buffer, "localvar_channel")
+    plugin = weechat.buffer_get_string(buffer, "plugin")
+    full_name = weechat.buffer_get_string(buffer, "full_name")
+    server = weechat.buffer_get_string(buffer, "localvar_server")
+    channel = weechat.buffer_get_string(buffer, "localvar_channel")
 
     if full_name.startswith("irc.server"):
-        return WEECHAT_RC_OK
+        return False
 
     buffer_type = weechat.buffer_get_string(
         weechat.info_get("irc_buffer", "{},{}".format(server, channel)),
@@ -142,7 +264,7 @@ def hide_buffer_cb(data, signal, signal_data):
 
     if (buffer_type == "private"
             and weechat.config_get_plugin("hide_private") == "off"):
-        return WEECHAT_RC_OK
+        return False
 
     if weechat.config_get_plugin("hide_inactive") == "off":
         nicks_count = 0
@@ -153,14 +275,19 @@ def hide_buffer_cb(data, signal, signal_data):
             nicks_count = weechat.infolist_integer(infolist, "nicks_count")
         weechat.infolist_free(infolist)
         if nicks_count == 0:
-            return WEECHAT_RC_OK
+            return False
 
     for entry in list_exemptions():
         if entry in full_name:
-            return WEECHAT_RC_OK
+            return False
 
-    weechat.buffer_set(previous_buffer, "hidden", "1")
-    return WEECHAT_RC_OK
+    return True
+
+
+def maybe_hide_buffer(buffer):
+    """Hide a buffer if all the conditions are met"""
+    if buffer_is_hidable(buffer):
+        weechat.buffer_set(buffer, "hidden", "1")
 
 
 def unhide_buffer_cb(data, signal, signal_data):
@@ -192,6 +319,7 @@ def unhide_buffer_cb(data, signal, signal_data):
             or hotlist[buffer]["count_message"] > 0
             or hotlist[buffer]["count_private"] > 0
             or hotlist[buffer]["count_highlight"] > 0):
+        remove_keep_alive(buffer)
         weechat.buffer_set(buffer, "hidden", "0")
 
     return WEECHAT_RC_OK
@@ -296,7 +424,7 @@ if (__name__ == '__main__' and import_ok and weechat.register(
     if int(weechat_version) >= 0x01000000:
         config_init()
         CURRENT_BUFFER = weechat.current_buffer()
-        weechat.hook_signal("buffer_switch", "hide_buffer_cb", "")
+        weechat.hook_signal("buffer_switch", "switch_buffer_cb", "")
         weechat.hook_signal("*,irc_in2_*", "unhide_buffer_cb", "")
         weechat.hook_command(
             SCRIPT_NAME,


### PR DESCRIPTION
This commit introduces the new configuration options `keep_open` and
`keep_open_timeout`. If `keep_open` is `off`, buffers that should get
hidden will be immediately hidden when switching buffers. Else, it will
be hidden after a certain timeout defined in `keep_open_timeout` has
been passed.

`keep_open_timeout` is given in milliseconds. It is possible to enter
the value as mathematical expression, i.e. `60 * 1000` for 60 milli-
seconds.