### PR TITLE
shortenurl.py 0.6.4: add user agent to fix 403 on is.gd

### DIFF
--- a/python/shortenurl.py
+++ b/python/shortenurl.py
@@ -14,6 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # History
+# 2019-02-20, Jochen Saalfeld <privat@jochen-saalfeld.de>
+#  version 0.6.4: Fix is.gd URL pulling
+#                 (fix displaying of shortened URL for is.gd)
 # 2018-11-02, Jochen Saalfeld <privat@jochen-saalfeld.de>
 #  version 0.6.3: Fix is.gd URL pattern
 #                 (api.php is depricated)
@@ -44,11 +47,11 @@
 import re
 import weechat
 from urllib import urlencode
-from urllib2 import urlopen
+import urllib2
 
 SCRIPT_NAME = "shortenurl"
 SCRIPT_AUTHOR = "John Anderson <sontek@gmail.com>"
-SCRIPT_VERSION = "0.6.3"
+SCRIPT_VERSION = "0.6.4"
 SCRIPT_LICENSE = "GPL3"
 SCRIPT_DESC = "Shorten long incoming and outgoing URLs"
 
@@ -150,7 +153,9 @@ def get_shortened_url(url):
     if shortener == 'tinyurl':
         url = TINYURL % urlencode({'url': url})
     try:
-        return urlopen(url).read()
+        opener = urllib2.build_opener()
+        opener.addheaders = [('User-Agent', 'weechat')]
+        return opener.open(url).read()
     except:
         return url
 


### PR DESCRIPTION
It seems that is.gd updated their policy and a 'User-Agent' is needed on requests. I shortly checked that with the following script:

```
import urllib2

string = "http://is.gd/api.php?longurl=https%3A%2F%2Fmedia.ccc.de%2Fv%2Fbiometrie-s8-iris "

req = urllib2.Request(string)
try:
    print("without agent:")
    res = urllib2.urlopen(req)
    ans = res.read()
    print(ans)
except Exception, e:
    print(e)

opener = urllib2.build_opener()
opener.addheaders = [('User-Agent', 'weechat')]
try:
    print("with agent:")
    resp = opener.open(string).read()
    print(resp)
except Exception, e:
    print(e)
```

which results in
```
without agent:
HTTP Error 403: Forbidden
with agent:
https://is.gd/Y3BSrS
```

And updated the plugin accordingly.