### PR TITLE
detach_away.py: Python3 support

### DIFF
--- a/python/detach_away.py
+++ b/python/detach_away.py
@@ -3,6 +3,9 @@
 # Copyright (C) 2017 p3lim <weechat@p3lim.net>
 #
 # https://github.com/p3lim/weechat-detach-away
+#
+# Changelog:
+# Ver: 0.1.1 Python3 support by Antonin Skala skala.antonin@gmail.com 3.2019
 
 try:
 	import weechat
@@ -11,11 +14,11 @@ except ImportError:
 	print('This script has to run under WeeChat (https://weechat.org/).')
 	exit(1)
 
-from urllib import urlencode
+from urllib.parse import urlencode
 
 SCRIPT_NAME = 'detach_away'
 SCRIPT_AUTHOR = 'p3lim'
-SCRIPT_VERSION = '0.1.0'
+SCRIPT_VERSION = '0.1.1'
 SCRIPT_LICENSE = 'MIT'
 SCRIPT_DESC = 'Automatically sets away message based on number of relays connected'
 
@@ -71,7 +74,7 @@ weechat.hook_signal('relay_client_connected', 'relay_connected', '')
 weechat.hook_signal('relay_client_disconnected', 'relay_disconnected', '')
 
 # register configuration defaults
-for option, value in SETTINGS.items():
+for option, value in list(SETTINGS.items()):
 	if not weechat.config_is_set_plugin(option):
 		weechat.config_set_plugin(option, value[0])
 

--- a/python/detach_away.py
+++ b/python/detach_away.py
@@ -6,65 +6,70 @@
 #
 # Changelog:
 # Ver: 0.1.1 Python3 support by Antonin Skala skala.antonin@gmail.com 3.2019
+# Ver: 0.1.2 Support Python 2 and 3 by Antonin Skala skala.antonin@gmail.com 3.2019
 
 try:
-	import weechat
+        import weechat
 except ImportError:
-	from sys import exit
-	print('This script has to run under WeeChat (https://weechat.org/).')
-	exit(1)
+        from sys import exit
+        print('This script has to run under WeeChat (https://weechat.org/).')
+        exit(1)
 
-from urllib.parse import urlencode
+import sys
+if sys.version_info[0] > 2:
+        from urllib.parse import urlencode
+else:
+        from urllib import urlencode
 
 SCRIPT_NAME = 'detach_away'
 SCRIPT_AUTHOR = 'p3lim'
-SCRIPT_VERSION = '0.1.1'
+SCRIPT_VERSION = '0.1.2'
 SCRIPT_LICENSE = 'MIT'
 SCRIPT_DESC = 'Automatically sets away message based on number of relays connected'
 
 SETTINGS = {
-	'message': (
-		'I am away',
-		'away message'),
-	'debugging': (
-		'off',
-		'debug flag'),
+        'message': (
+                'I am away',
+                'away message'),
+        'debugging': (
+                'off',
+                'debug flag'),
 }
 
 num_relays = 0
 
 def DEBUG():
-	return weechat.config_get_plugin('debug') == 'on'
+        return weechat.config_get_plugin('debug') == 'on'
 
 def set_away(is_away, message=''):
-	if is_away:
-		message = weechat.config_get_plugin('message')
+        if is_away:
+                message = weechat.config_get_plugin('message')
 
-	weechat.command('', '/away -all ' + message)
+        weechat.command('', '/away -all ' + message)
 
 def relay_connected(data, signal, signal_data):
-	global num_relays
+        global num_relays
 
-	if DEBUG():
-		weechat.prnt('', 'DETACH_AWAY: last #relays: ' + str(num_relays))
+        if DEBUG():
+                weechat.prnt('', 'DETACH_AWAY: last #relays: ' + str(num_relays))
 
-	if int(num_relays) == 0:
-		set_away(False)
+        if int(num_relays) == 0:
+                set_away(False)
 
-	num_relays = weechat.info_get('relay_client_count', 'connected')
-	return weechat.WEECHAT_RC_OK
+        num_relays = weechat.info_get('relay_client_count', 'connected')
+        return weechat.WEECHAT_RC_OK
 
 def relay_disconnected(data, signal, signal_data):
-	global num_relays
+        global num_relays
 
-	if DEBUG():
-		weechat.prnt('', 'DETACH_AWAY: last #relays: ' + str(num_relays))
+        if DEBUG():
+                weechat.prnt('', 'DETACH_AWAY: last #relays: ' + str(num_relays))
 
-	if int(num_relays) > 0:
-		set_away(True)
+        if int(num_relays) > 0:
+                set_away(True)
 
-	num_relays = weechat.info_get('relay_client_count', 'connected')
-	return weechat.WEECHAT_RC_OK
+        num_relays = weechat.info_get('relay_client_count', 'connected')
+        return weechat.WEECHAT_RC_OK
 
 # register plugin
 weechat.register(SCRIPT_NAME, SCRIPT_AUTHOR, SCRIPT_VERSION, SCRIPT_LICENSE, SCRIPT_DESC, '', '')
@@ -74,8 +79,13 @@ weechat.hook_signal('relay_client_connected', 'relay_connected', '')
 weechat.hook_signal('relay_client_disconnected', 'relay_disconnected', '')
 
 # register configuration defaults
-for option, value in list(SETTINGS.items()):
-	if not weechat.config_is_set_plugin(option):
-		weechat.config_set_plugin(option, value[0])
-
-	weechat.config_set_desc_plugin(option, '%s (default: "%s")' % (value[1], value[0]))
+if sys.version_info[0] > 2:
+        for option, value in list(SETTINGS.items()):
+                if not weechat.config_is_set_plugin(option):
+                        weechat.config_set_plugin(option, value[0])
+                weechat.config_set_desc_plugin(option, '%s (default: "%s")' % (value[1], value[0]))
+else:
+        for option, value in SETTINGS.items():
+                if not weechat.config_is_set_plugin(option):
+                        weechat.config_set_plugin(option, value[0])
+                weechat.config_set_desc_plugin(option, '%s (default: "%s")' % (value[1], value[0]))


### PR DESCRIPTION
Hello, I edited this to support Python 3. Tested on Weechat 2.5-dev and works well.
```
python: registered script "test", version test (test)
3.6.7 (default, Oct 22 2018, 11:32:17) 
[GCC 8.2.0]
['/home/weechat/.weechat/python', '', '/usr/lib/python36.zip', '/usr/lib/python3.6', '/usr/lib/python3.6/lib-dynload', '/usr/local/lib/python3.6/dist-packages', '/usr/local/lib/python3.6/dist-packages/async_upnp_client-0.14.5.dev0-py3.6.egg', '/usr/local/lib/python3.6/dist-packages/voluptuous-0.11.5-py3.6.egg', '/usr/local/lib/python3.6/dist-packages/python_didl_lite-1.2.3-py3.6.egg', '/usr/local/lib/python3.6/dist-packages/defusedxml-0.5.0-py3.6.egg', '/usr/local/lib/python3.6/dist-packages/async_timeout-3.0.1-py3.6.egg', '/usr/local/lib/python3.6/dist-packages/aiohttp-4.0.0a0-py3.6-linux-x86_64.egg', '/usr/local/lib/python3.6/dist-packages/yarl-1.3.0-py3.6-linux-x86_64.egg', '/usr/local/lib/python3.6/dist-packages/typing_extensions-3.7.2-py3.6.egg', '/usr/local/lib/python3.6/dist-packages/multidict-4.5.2-py3.6-linux-x86_64.egg', '/usr/local/lib/python3.6/dist-packages/idna_ssl-1.1.0-py3.6.egg', '/usr/local/lib/python3.6/dist-packages/attrs-18.2.0-py3.6.egg', '/usr/lib/python3/dist-packages']
```