### PR TITLE
highmon.pl v2.6: improvement - send logger_backlog signal if logging enabled

### DIFF
--- a/perl/highmon.pl
+++ b/perl/highmon.pl
@@ -322,11 +322,7 @@ sub highmon_buffer_open
 		# send "logger_backlog" signal if logging is enabled to display backlog
 		if (weechat::config_get_plugin("logging") eq "on")
 		{
-			# this should be true only if logger plugin is loaded and auto_log is enabled
-			if (weechat::config_get("logger.file.auto_log"))
-			{
-				weechat::hook_signal_send("logger_backlog", weechat::WEECHAT_HOOK_SIGNAL_POINTER, $highmon_buffer)
-			}
+			weechat::hook_signal_send("logger_backlog", weechat::WEECHAT_HOOK_SIGNAL_POINTER, $highmon_buffer)
 		}
 	}
 	return weechat::WEECHAT_RC_OK;

--- a/perl/highmon.pl
+++ b/perl/highmon.pl
@@ -317,6 +317,11 @@ sub highmon_buffer_open
 		{
 			weechat::buffer_set($highmon_buffer, "localvar_set_no_log", "1");
 		}
+		# send "logger_backlog" signal if logging is enabled to display backlog
+		if (weechat::config_get_plugin("logging") eq "on")
+		{
+			weechat::hook_signal_send("logger_backlog", weechat::WEECHAT_HOOK_SIGNAL_POINTER, $highmon_buffer)
+		}
 	}
 	return weechat::WEECHAT_RC_OK;
 }

--- a/perl/highmon.pl
+++ b/perl/highmon.pl
@@ -1,6 +1,6 @@
 #
 # highmon.pl - Highlight Monitoring for weechat 0.3.0
-# Version 2.5
+# Version 2.6
 #
 # Add 'Highlight Monitor' buffer/bar to log all highlights in one spot
 #
@@ -73,6 +73,8 @@
 # Bugs and feature requests at: https://github.com/KenjiE20/highmon
 
 # History:
+# 2019-05-13, HubbeKing <hubbe128@gmail.com>
+#       v2.6:   -add: send "logger_backlog" signal on buffer open if logging is enabled
 # 2014-08-16, KenjiE20 <longbow@longbowslair.co.uk>:
 #	v2.5:	-add: clearbar command to clear bar output
 #			-add: firstrun output prompt to check the help text for set up hints as they were being missed

--- a/perl/highmon.pl
+++ b/perl/highmon.pl
@@ -74,7 +74,7 @@
 
 # History:
 # 2019-05-13, HubbeKing <hubbe128@gmail.com>
-#       v2.6:   -add: send "logger_backlog" signal on buffer open if logging is enabled
+#       v2.6:   -add: send "logger_backlog" signal on buffer open if logging is enabled and logger plugin is loaded.
 # 2014-08-16, KenjiE20 <longbow@longbowslair.co.uk>:
 #	v2.5:	-add: clearbar command to clear bar output
 #			-add: firstrun output prompt to check the help text for set up hints as they were being missed
@@ -308,7 +308,7 @@ sub highmon_buffer_open
 	# Turn off notify, highlights
 	if ($highmon_buffer ne "")
 	{
-		if (weechat::config_get_plugin("hotlist_show" eq "off"))
+		if (weechat::config_get_plugin("hotlist_show") eq "off")
 		{
 			weechat::buffer_set($highmon_buffer, "notify", "0");
 		}
@@ -322,7 +322,11 @@ sub highmon_buffer_open
 		# send "logger_backlog" signal if logging is enabled to display backlog
 		if (weechat::config_get_plugin("logging") eq "on")
 		{
-			weechat::hook_signal_send("logger_backlog", weechat::WEECHAT_HOOK_SIGNAL_POINTER, $highmon_buffer)
+			# this should be true only if logger plugin is loaded and auto_log is enabled
+			if (weechat::config_get("logger.file.auto_log"))
+			{
+				weechat::hook_signal_send("logger_backlog", weechat::WEECHAT_HOOK_SIGNAL_POINTER, $highmon_buffer)
+			}
 		}
 	}
 	return weechat::WEECHAT_RC_OK;


### PR DESCRIPTION
Script author hasn't done anything on github since 2014, thought I'd fix this thing which'd been bugging me for months.

highmon buffer now sends a "logger_backlog" signal once the buffer has been opened, if logging is enabled and the logger plugin appears to be loaded. 
This makes highmon.pl more usable in situations where one needs to frequently restart weechat.