### PR TITLE
shortenurl.py: Correction of small bugs

### DIFF
--- a/python/shortenurl.py
+++ b/python/shortenurl.py
@@ -14,6 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # History
+# 2019-10-10, CrazyCat <crazycat@c-p-f.org>
+#  version 0.6.6: fix trouble of "b'"
+#    : fix short_own=off bug when user is @,% or +
 # 2019-10-01, Cian Butler <butlerx@notthe.cloud>
 #  version 0.6.5: make script compatible with Python 3
 # 2019-02-20, Jochen Saalfeld <privat@jochen-saalfeld.de>
@@ -57,7 +60,7 @@ except ImportError:
 
 SCRIPT_NAME = "shortenurl"
 SCRIPT_AUTHOR = "John Anderson <sontek@gmail.com>"
-SCRIPT_VERSION = "0.6.5"
+SCRIPT_VERSION = "0.6.6"
 SCRIPT_LICENSE = "GPL3"
 SCRIPT_DESC = "Shorten long incoming and outgoing URLs"
 
@@ -108,6 +111,7 @@ def notify(data, buf, date, tags, displayed, hilight, prefix, msg):
     reset = weechat.color('reset')
 
     my_nick = weechat.buffer_get_string(buf, 'localvar_nick')
+    prefix = re.sub(r'^[@%+~]', r'', prefix)
     if prefix != my_nick:
         urls = find_and_process_urls(msg)
 
@@ -161,7 +165,7 @@ def get_shortened_url(url):
     try:
         opener = build_opener()
         opener.addheaders = [('User-Agent', 'weechat')]
-        return opener.open(url).read()
+        return opener.open(url).read().decode('utf-8')
     except:
         return url
 


### PR DESCRIPTION
Corrected encoding trouble (with tinyurl ?) showing [ b'http://tinyurl.com/abcdef' ]
Corrected a trouble making show_own not working when user is op, halfop or voice