### PR TITLE
grep.py: fix a few more python3 errors

### DIFF
--- a/python/grep.py
+++ b/python/grep.py
@@ -596,7 +596,10 @@ def get_file_by_name(buffer_name):
             if '$server' in mask:
                 mask = mask.replace('$server', server)
         # change the unreplaced vars by '*'
-        from string import letters
+        try:
+            from string import letters
+        except ImportError:
+            from string import ascii_letters as letters
         if '%' in mask:
             # vars for time formatting
             mask = mask.replace('%', '$')

--- a/python/grep.py
+++ b/python/grep.py
@@ -1741,8 +1741,11 @@ Examples:
             debug = pybuffer.debugBuffer(globals(), '%s_debug' % SCRIPT_NAME)
         except:
             def debug(s, *args):
-                if not isinstance(s, basestring):
-                    s = str(s)
+                try:
+                    if not isinstance(s, basestring):
+                        s = str(s)
+                except NameError:
+                    pass
                 if args:
                     s = s %args
                 prnt('', '%s\t%s' %(script_nick, s))

--- a/python/grep.py
+++ b/python/grep.py
@@ -69,6 +69,9 @@
 #
 #   History:
 #
+#   2019-10-11, hexa-
+#   version 0.8.3: correct a few more python3 errors
+#
 #   2019-06-30, dabbill <dabbill@gmail.com>
 #               and Sébastien Helleu <flashcode@flashtux.org>
 #   version 0.8.2: make script compatible with Python 3
@@ -230,7 +233,7 @@ except ImportError:
 
 SCRIPT_NAME    = "grep"
 SCRIPT_AUTHOR  = "Elián Hanisch <lambdae2@gmail.com>"
-SCRIPT_VERSION = "0.8.2"
+SCRIPT_VERSION = "0.8.3"
 SCRIPT_LICENSE = "GPL3"
 SCRIPT_DESC    = "Search in buffers and logs"
 SCRIPT_COMMAND = "grep"

--- a/python/grep.py
+++ b/python/grep.py
@@ -1549,7 +1549,7 @@ def cmd_logs(data, buffer, args):
     if get_config_boolean('clear_buffer'):
         weechat.buffer_clear(buffer)
     file_list = zip(file_list, file_sizes)
-    msg = 'Found %s logs.' %len(file_list)
+    msg = 'Found %s logs.' % len(list(file_list))
 
     print_line(msg, buffer, display=True)
     for file, size in file_list:


### PR DESCRIPTION
```py3tb
Traceback (most recent call last):
  File "/var/lib/weechat/python/autoload/grep.py", line 1552, in cmd_logs
    msg = 'Found %s logs.' %len(file_list)
TypeError: object of type 'zip' has no len()
```

While `zip()` has a length in python2 it is lazy in python3 and needs to be evaluated first. Fix by evaluating the iterator before calculating it's length.

Calling list on a list in python2 is idempotent, so this keeps compatibility intact.