### PR TITLE
im_rename.py: work with bitlbee-purple and localhost using ubuntu repos 01/2020

### DIFF
--- a/python/im_rename.py
+++ b/python/im_rename.py
@@ -4,19 +4,20 @@
 # Based on the Irssi script at http://browsingtheinternet.com/temp/bitlbee_rename.txt
 # Ported for Weechat 0.3.0 or later by Jaakko Lintula (crwl@iki.fi)
 # Modified for Minbif by 'varogami' <varogami@gmail.com>
+# Remodified for Bitlbee-purple on localhost by Abhishek Cherath <abhicherath@gmail.com>
 #
 # This script is in the public domain.
 
 
 # Edit this variables with your own minbif/bitlbee configuration settings
-fullname="Full Name"       # set the first word in full name string that "/WHOIS nick nick" or /WII show
-                           # italian - fullname="Nome"
-                           # spanish - fullname="Nombre completo"
-                           # english - fullname="Full Name"
-myChannel = "&minbif" # set "&bitlbee" or "&minbif" if you use default settings
-myServer = "minbif" # set "bitlbee" or "minbif" if you use default settings
+myChannel = "&bitlbee" # set "&bitlbee" or "&minbif" if you use default settings
+myServer = "localhost" # set "bitlbee" or "minbif" if you use default settings
 
-facebookhostname = "chat.facebook.com"
+#minbif seems really old and unused at this point shift to only bitlbee? 
+#looking around on net hangouts doesn't seem to need this tool so only keep facebook?
+
+#facebookhostname = "chat.facebook.com"
+facebookhostname = "facebook" #this is the new host name for facebook messenger
 gmailhostname = "public.talk.google.com"
 
 myBuffer = "%s.%s" % (myServer, myChannel)
@@ -25,19 +26,21 @@ nicksToRename = set()
 import weechat
 import re
 
-weechat.register("im_rename", "crwl", "1.2", "Public Domain", "Renames Facebook anf Google Plus usernames with Minbif", "", "")
+weechat.register("im_rename", "crwl", "1.2", "Public Domain", "Renames Facebook usernames with Bitlbee", "", "") #google plus no longer exists
 
 def message_join_minbif(data, signal, signal_data):
+  """When someone logs on call whois in server"""
   signal_data = signal_data.split()
-  channel = signal_data[2]
+  channel = signal_data[2][signal_data[2].index(':')+1:]
   hostmask = signal_data[0]
   nick = hostmask[1:hostmask.index('!')]
-  username = hostmask[hostmask.index('!')+1:hostmask.index('@')]
+  username ="_"+ hostmask[hostmask.index('!')+1:hostmask.index('@')]
   server = hostmask[hostmask.index('@')+1:]
   if server.find(':') > 1:
     server = server[:+server.index(':')]
 
-  if channel == myChannel and nick == username and nick[0] == '-' and server == facebookhostname:
+ # if channel == myChannel and nick == username and nick[0] == '-' and server == facebookhostname:
+  if channel == myChannel and nick == username and nick[0] == '_' and server == facebookhostname:
    nicksToRename.add(nick)
    weechat.command(weechat.buffer_search("irc", myBuffer), "/whois "+nick+" "+nick)
 
@@ -48,22 +51,22 @@ def message_join_minbif(data, signal, signal_data):
   return weechat.WEECHAT_RC_OK
 
 def whois_data_minbif(data, signal, signal_data):
-  if fullname in signal_data:
-   nick = signal_data.split(fullname)[0].strip()
-   nick = nick[1:nick.index(' :')]
-   nick = nick.split(' ')
-   nick = nick[3]
-   realname =  signal_data.split(fullname)[1].strip()
+  """Get data from irc_in_311 and parse name from there. """
+  if "facebook" in signal_data:
+    realname = signal_data[signal_data.index(" :"):].strip(" :")
+    nick = signal_data[signal_data.index("_"):signal_data.index(" ",signal_data.index("_"))]
+    weechat.prnt("",str(nicksToRename))
 
-   if nick in nicksToRename:
-     nicksToRename.remove(nick)
-     ircname = re.sub("[^A-Za-z0-9]", "", realname)[:24]
-     if ircname != nick:
-       weechat.command(weechat.buffer_search("irc", myBuffer), "/quote -server %s svsnick %s %s" % (myServer, nick, ircname))
+  if nick in nicksToRename:
+    nicksToRename.remove(nick)
+    ircname = re.sub("[^A-Za-z0-9]", "", realname)[:24]
+    weechat.prnt("",ircname)
+    if ircname != nick:
+      weechat.command(weechat.buffer_search("irc", myBuffer), "rename %s %s" %  (nick, ircname))
 
   return weechat.WEECHAT_RC_OK
 
 
 
-weechat.hook_signal(myServer+",irc_in_join", "message_join_minbif", "")
-weechat.hook_signal(myServer+",irc_in_320", "whois_data_minbif", "")
+weechat.hook_signal(myServer+",irc_in_join", "message_join_minbif", "") #calls message_join_minbif when someone joins the channel
+weechat.hook_signal(myServer+",irc_in_311", "whois_data_minbif", "") #calls the facebook name reassigner when /whois is called.


### PR DESCRIPTION
…g ubuntu repos 01/2020

Hello,

so im_rename wasn't really working with the current facebook protocol, so I made some changes to make it work. But I'm not sure why irc_in_311 works. Also how can I make this work with weechat set stuff so users don't have to edit source?

Thank you,
Abhishek Cherath.