### PR TITLE
perl-recoverop.pl: Prevent error caused by wait with 0s in weechat 2.7

### DIFF
--- a/perl/recoverop.pl
+++ b/perl/recoverop.pl
@@ -48,7 +48,7 @@ use warnings;
 
 weechat::register(
     "recoverop", "AYANOKOUZI, Ryuunosuke",
-    "0.1.1", "GPL3", "recover channel operator in empty channel",
+    "0.1.2", "GPL3", "recover channel operator in empty channel",
     "", ""
 );
 my $script_name = "recoverop";
@@ -91,7 +91,7 @@ sub part_join {
                   weechat::buffer_search( "irc", "$server.$channel" );
                 if ($buffer)
                 {
-                    my $sec = int rand 10;
+                    my $sec = 1 + int rand 10;
                     weechat::command( $buffer, "/wait ${sec}s /cycle" );
                     if ($conf->{mode})
                     {


### PR DESCRIPTION
As discussed on irc:

```irc
09:12 <TauPan> Hm... I see an error message that there was a problem with the command "/wait 0s /cycle" ... that must be some script or trigger that has a timeout off 0 and (stupidly) calls /wait nonetheless. How do I figure out what might be causing this?
09:13 <TauPan> (This message appears since a couple of days or weeks, so it might have occured since a recent update or so. Or I configuration change? I really have no idea.)
[...]
09:14 <TauPan> (I have no setting that matches wait, timeout or cycle )
09:15 <guestkato> i would grep the scripts for "wait" and try to trigger each of those cases
09:18 <TauPan> (==0 doesn't turn up anything either, so it's probably not a setting)
09:18 <j0k> perhaps a python script
09:18 <TauPan> Yeah, I'll grep for wait.
09:19 <j0k> python 2 had become version 3
09:20 <guestkato> on a glance at the original /wait code, it might have accidentally skipped running the command if the time were 0, but that was changed to error
09:20 <TauPan> I've hand-ported my python scripts from 2 to 3 earlier last year, but I don't think it happened back then.
[...]
09:20 <guestkato> hopefully the script doesn't rely on that erroneous behavior
09:21 <TauPan> Interesting... I'm on weechat 2.7 since mid-december on this box here.
09:21 <TauPan> Could fit with the timeline.
09:21 <guestkato> the change was in last march at the lastest
09:21 <TauPan> Ah, it's perl-recoverop.pl, pretty sure...
09:21 <@FlashCode> TauPan: /wait 0s /xxx schedules the command later, and even with 0s, this forces weechat to re-enter in its main loop, do all refreshes, etc, before running the command
09:21 <@FlashCode> so it may have sense to do that
09:22 <@FlashCode> in some cases
09:23 <TauPan>                     my $sec = int rand 10;
09:23 <TauPan>                     weechat::command( $buffer, "/wait ${sec}s /cycle" );
09:23 <TauPan> rand 10 includes 0 in perl?
09:24 <guestkato> yes, since int rounds [0,1) to 0
09:24 <guestkato> truncates, not rounds. you could just do = 1 + int rand 10
09:24 <TauPan> (Apparently yes: https://perldoc.perl.org/functions/rand.html thanks, guestkato)
09:27 <TauPan> Ok... sorry to be that guy now (and for the noise) but it has just occured to me that on the only network where this used to be relevant I'm on a restricted connection now and can't get chanop anyways, so I deleted the script.
09:30 <TauPan> Btw. is there some (opt-in) statistics to check which scripts are actually being used? I've recently stumbled across country.py which doesn't cope with ipv6 and is hardly useful nowadays and others might also be obsolete or outdated.
09:37 <@FlashCode> TauPan: there's some (outdated) stats here: https://weechat.org/dev/stats/scripts/
09:37 <@FlashCode> (bottom of page)
09:51 <TauPan> If I make a pull request just with the 1 + change that guestkato propose, do I need to increase the version number of the script?
09:51 <TauPan> *proposed
```