### PR TITLE
Fix unparseable indentation error in queue.py

### DIFF
--- a/python/queue.py
+++ b/python/queue.py
@@ -274,8 +274,8 @@ def qu_cb(data, buffer, args):
 	else:
 		rainbowit=1
 
-        if args == "":
-                return weechat.WEECHAT_RC_OK
+	if args == "":
+		return weechat.WEECHAT_RC_OK
 
 	argv = args.split()
 	arglist = ['add', 'del', 'new', 'dellist', 'list', 'clear', 'exec', 'listview', 'save', 'set']


### PR DESCRIPTION
This PR fixes an unparseable indentation level present in queue.py.

How to reproduce error:

- Install weechat with python 3.8
- Install weechat matrix
- load script matrix.py

Result: Indentation error in queue.py:277
Expected result: matrix.py loads successfully