### PR TITLE
tmux_env.py 3.1: Fix compatibility problem with python 3.6 and kill python 2 support

### DIFF
--- a/python/tmux_env.py
+++ b/python/tmux_env.py
@@ -24,6 +24,9 @@ History:
 
     2020-01-03 dobbymoodge <john.w.lamb [at] gmail . com> ( https://github.com/dobbymoodge/ )
       version 3: python 3.x compatibility
+
+    2020-10-30 Friedrich Delgado <taupan [at] gmail . com>
+      version 3.1: fix one missing instance of **check_output_kwargs
 """
 
 from __future__ import absolute_import, unicode_literals
@@ -34,24 +37,9 @@ import fnmatch
 import os
 import subprocess
 
-if not hasattr(subprocess, 'check_output'):
-    def check_output(*popenargs, **kwargs):
-        process = subprocess.Popen(stdout=subprocess.PIPE,
-                                   *popenargs, **kwargs)
-        output, unused_err = process.communicate()
-        retcode = process.poll()
-        if retcode:
-            cmd = kwargs.get("args")
-            if cmd is None:
-                cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd)
-        return output
-    subprocess.check_output = check_output
-    del check_output
-
 SCRIPT_NAME = "tmux_env"
 SCRIPT_AUTHOR = "Aron Griffis <agriffis@n01se.net>"
-SCRIPT_VERSION = "3"
+SCRIPT_VERSION = "3.1"
 SCRIPT_LICENSE = "GPL3"
 SCRIPT_DESC = "Update weechat environment from tmux"
 
@@ -69,8 +57,6 @@ settings = {
     'include': '*,-*',  # Env vars to include, default all
     'exclude': '',      # Env vars to exclude, default all
     }
-
-check_output_kwargs = {'text': True}
 
 TIMER = None
 
@@ -102,21 +88,10 @@ def timer_cb(buffer, args):
     return w.WEECHAT_RC_OK
 
 
-def do_check_output(command_args):
-    """Wrap `subprocess.check_output` to detect and account for
-    python2/python3 variations"""
-    global check_output_kwargs
-    try:
-        return subprocess.check_output(command_args, **check_output_kwargs)
-    except TypeError:
-        del(check_output_kwargs['text'])
-        return subprocess.check_output(command_args, **check_output_kwargs)
-
-
 def update_environment():
     """Updates environment from tmux showenv"""
 
-    env = subprocess.check_output(['tmux', 'showenv'], text=True)
+    env = subprocess.check_output(['tmux', 'showenv']).decode()
     for line in env.splitlines():
         name = line.split('=', 1)[0]
         if check_include(name) and not check_exclude(name):

--- a/python/tmux_env.py
+++ b/python/tmux_env.py
@@ -26,7 +26,7 @@ History:
       version 3: python 3.x compatibility
 
     2020-10-30 Friedrich Delgado <taupan [at] gmail . com>
-      version 3.1: fix one missing instance of **check_output_kwargs
+      version 3.1: fix python 3.6 compatibility and remove python 2 support
 """
 
 from __future__ import absolute_import, unicode_literals


### PR DESCRIPTION
I got the following backtrace with python 3.6 (which is still
supported and default on some distribution).

And testing with python2 seemed to complicated, so I simply removed
the text kwarg and called .decode() on the result.

See
https://docs.python.org/3.6/library/subprocess.html#subprocess.check_output

as opposed to:

https://docs.python.org/3.7/library/subprocess.html#subprocess.check_output

I don't know what would be necessary to still support python 2, also
that would entail support for 3 different python versions.

~~~python
08:29 python: stdout/stderr: (tmux_env): Traceback (most recent call last):
08:29 python: stdout/stderr: (tmux_env):   File "/home/delgado/.weechat/python/autoload/tmux_env.py", line 101, in timer_cb
08:29 python: stdout/stderr: (tmux_env):     update_environment()
08:29 python: stdout/stderr: (tmux_env):   File "/home/delgado/.weechat/python/autoload/tmux_env.py", line 119, in update_environment
08:29 python: stdout/stderr: (tmux_env):     env = subprocess.check_output(['tmux', 'showenv'], **check_output_kwargs)
08:29 python: stdout/stderr: (tmux_env):   File "/usr/lib64/python3.6/subprocess.py", line 356, in check_output
08:29 python: stdout/stderr: (tmux_env):     **kwargs).stdout
08:29 python: stdout/stderr: (tmux_env):   File "/usr/lib64/python3.6/subprocess.py", line 423, in run
08:29 python: stdout/stderr: (tmux_env):     with Popen(*popenargs, **kwargs) as process:
08:29 python: stdout/stderr: (tmux_env): TypeError: __init__() got an unexpected keyword argument 'text'
~~~