### PR TITLE
urlgrab.py: change urlgrab buffer to open the URL with <Return>

### DIFF
--- a/python/urlgrab.py
+++ b/python/urlgrab.py
@@ -652,7 +652,7 @@ def init():
         weechat.buffer_set(urlgrab_buffer, "key_bind_meta2-A",       "/url **up")
         weechat.buffer_set(urlgrab_buffer, "key_bind_meta2-B",       "/url **down")
         weechat.buffer_set(urlgrab_buffer, "key_bind_meta-ctrl-J",   "/url **enter")
-        weechat.buffer_set(urlgrab_buffer, "key_bind_meta-ctrl-M",   "/url **enter")
+        weechat.buffer_set(urlgrab_buffer, "key_bind_ctrl-M",        "/url **enter")
         weechat.buffer_set(urlgrab_buffer, "key_bind_meta-meta2-1./~", "/url **scroll_top")
         weechat.buffer_set(urlgrab_buffer, "key_bind_meta-meta2-4~", "/url **scroll_bottom")
         weechat.buffer_set(urlgrab_buffer, "title","Lists the urls in the applications")
@@ -687,7 +687,7 @@ if ( import_ok and
                              "Url Grabber",
                              "[open <url> | <url> | show | copy [n] | [n] | list]",
                              "open or <url>: opens the url\n"
-                             "show: Opens the select buffer to allow for url selection\n"
+                             "show: Opens a buffer where you can select a URL. Using <return> or <ctrl><alt>j opens it.\n"
                              "copy: Copies the nth url to the system clipboard\n"
                              "list: Lists the urls in the current buffer\n",
                              "open %(urlgrab_urls) || %(urlgrab_urls) || "


### PR DESCRIPTION
Urlgrab.py adds some keyboard shortcuts, to open a URL when the user is in the buffer. The current behaviour is that you have to use <alt><return>, changed to be just plain <return>. The shortcut is limited to this buffer AFAICT. Also added it to the documentation as it doesn't tell you there are keyboard shortcuts.

There's an old issue #72 that mentions this