### PR TITLE
colorize_nicks.py 28: fix ignore_tags, broken by weechat 2.9 changes

### DIFF
--- a/python/colorize_nicks.py
+++ b/python/colorize_nicks.py
@@ -21,6 +21,8 @@
 #
 #
 # History:
+# 2020-11-29: jess
+#   version 28: fix ignore_tags having been broken by weechat 2.9 changes
 # 2020-05-09: Sébastien Helleu <flashcode@flashtux.org>
 #   version 27: add compatibility with new weechat_print modifier data
 #               (WeeChat >= 2.9)
@@ -88,7 +90,7 @@ w = weechat
 
 SCRIPT_NAME    = "colorize_nicks"
 SCRIPT_AUTHOR  = "xt <xt@bash.no>"
-SCRIPT_VERSION = "27"
+SCRIPT_VERSION = "28"
 SCRIPT_LICENSE = "GPL"
 SCRIPT_DESC    = "Use the weechat nick colors in the chat area"
 
@@ -184,6 +186,7 @@ def colorize_cb(data, modifier, modifier_data, line):
         buffer = w.buffer_search(plugin, buffer_name)
 
     channel = w.buffer_get_string(buffer, 'localvar_channel')
+    tags = tags.split(',')
 
     # Check if buffer has colorized nicks
     if buffer not in colored_nicks:
@@ -196,12 +199,10 @@ def colorize_cb(data, modifier, modifier_data, line):
     reset = w.color('reset')
 
     # Don't colorize if the ignored tag is present in message
-    tags_line = modifier_data.rsplit(';')
-    if len(tags_line) >= 3:
-        tags_line = tags_line[2].split(',')
-        for i in w.config_string(colorize_config_option['ignore_tags']).split(','):
-            if i in tags_line:
-                return line
+    tag_ignores = w.config_string(colorize_config_option['ignore_tags']).split(',')
+    for tag in tags:
+        if tag in tag_ignores:
+            return line
 
     for words in valid_nick_re.findall(line):
         nick = words[1]


### PR DESCRIPTION
simple fix: referencing `modifier_data` is no longer correct because it needs version-specific parsing, which was already being done.

I notice there's a couple of other `colorize_nicks.py` PRs - I'm happy to fix this PR if those are merged first!