### PR TITLE
grep.py: ignore utf-8 decoding errors

### DIFF
--- a/python/grep.py
+++ b/python/grep.py
@@ -730,7 +730,7 @@ def grep_file(file, head, tail, after_context, before_context, count, regexp, hi
         check = lambda s: check_string(s, regexp, hilight, exact)
 
     try:
-        file_object = open(file, 'r')
+        file_object = open(file, 'r', errors='ignore')
     except IOError:
         # file doesn't exist
         return lines


### PR DESCRIPTION
They prevent grep from working on logs, which contain incorrectly split international messages (i.e. message containing 242 utf-8 chars and 3 spaces (484 + 3 bytes) was split like 243+244 bytes, rendering utf-8 undecodable in the second message)