### PR TITLE
url_olde.py: Python 3 fix

### DIFF
--- a/python/url_olde.py
+++ b/python/url_olde.py
@@ -21,7 +21,7 @@ try:
     import sqlite3
     import time
     import re
-    from urlparse import urldefrag
+    from urllib.parse import urldefrag
     IMPORT_ERR = 0
 except ImportError:
     IMPORT_ERR = 1


### PR DESCRIPTION
urldefrag is no longer in urlparse, but rather in [urllib.parse](https://docs.python.org/3.7/library/urllib.parse.html)