### PR TITLE
Fix minor typo.

### DIFF
--- a/python/histman.py
+++ b/python/histman.py
@@ -389,7 +389,7 @@ if __name__ == '__main__':
                             'The command history of a buffer will be saved \"only\", if the the local variable \"save_history\" is set.\n'
                             'You will need script \"buffer_autoset.py\" to make a local variabe persistent (see examples, below)!!\n'
                             '\n'
-                            'You can use option \"save_buffer\ to save command history for *all* buffers, localvar will be ignored using\n'
+                            'You can use option \"save_buffer\" to save command history for *all* buffers, localvar will be ignored using\n'
                             'this option.\n'
                             'You can use following values for local variable:\n'
                             '  command: save commands only\n'

--- a/python/histman.py
+++ b/python/histman.py
@@ -60,7 +60,7 @@ except Exception:
 
 SCRIPT_NAME     = 'histman'
 SCRIPT_AUTHOR   = 'nils_2 <weechatter@arcor.de>'
-SCRIPT_VERSION  = '0.8'
+SCRIPT_VERSION  = '0.8.1'
 SCRIPT_LICENSE  = 'GPL'
 SCRIPT_DESC     = 'save and restore global and/or buffer command history'
 


### PR DESCRIPTION
Hi, this is a fix for a minor typo in the documentation for `histman.py`. Thanks!