### PR TITLE
gnome_screensaver_away.py 0.2.1: Add missing call to infolist_free

### DIFF
--- a/python/gnome_screensaver_away.py
+++ b/python/gnome_screensaver_away.py
@@ -25,6 +25,9 @@
 #             - Allow configuration of message and poll time
 #             - Tolerate gnome-shell crashes
 #
+# 2021-04-05: Sébastien Helleu <flashcode@flashtux.org>
+#     0.2.1 : - Add missing call to infolist_free
+#
 # Contributions welcome at:
 # https://github.com/grdryn/weechat-gnome-screensaver-away
 
@@ -39,7 +42,7 @@ except ImportError:
 
 SCRIPT_NAME    = 'gnome-screensaver-away'
 SCRIPT_AUTHOR  = 'Gerard Ryan <gerard@ryan.lt>'
-SCRIPT_VERSION = '0.2.0'
+SCRIPT_VERSION = '0.2.1'
 SCRIPT_LICENSE = 'GPLv3+'
 SCRIPT_DESC    = 'Set away status based on GNOME ScreenSaver status'
 
@@ -55,7 +58,7 @@ def get_poll_interval_safely():
     try:
         poll_interval = int(weechat.config_get_plugin('poll_interval'))
     except ValueError:
-        weechat.println('poll_interval is not an int, falling back to default')
+        weechat.prnt('', 'poll_interval is not an int, falling back to default')
 
     return poll_interval
 
@@ -71,6 +74,8 @@ def check_away_status():
         is_away_by_me = current_away_msg == auto_away_msg
         is_away       = bool(weechat.infolist_integer(irc_servers, "is_away"))
         away          = (is_away, is_away_by_me)
+
+    weechat.infolist_free(irc_servers)
 
     return away
 


### PR DESCRIPTION
## Script info

<!-- MANDATORY INFO: -->

- Script name: gnome_screensaver_away.py
- Version: 0.2.1

<!-- Optional: external dependencies (other than WeeChat and standard interpreter libraries) -->
- Requirements: dbus-python

<!-- Optional: fill only if you are sure that a specific WeeChat version is required -->
- Min WeeChat version: 0.3.0

<!-- Optional: tags for script (see list of tags on https://weechat.org/scripts/), new tags are allowed -->
- Script tags: 

## Description

<!-- Describe the new script or your changes in a few sentences -->



## Checklist (new script)

## Checklist (script update)

<!-- To fill only if you are updating an existing script -->

<!-- Please validate and check each item with "[x]" (see file Contributing.md) -->

- [x] Author has been contacted
- [x] Single commit, single file added
- [x] Commit message format: `script_name.py X.Y: …`
- [x] Script version and Changelog have been updated
- [ ] For Python script: works with Python 3 (Python 2 support is optional)


@flashcode I haven't marked this as Python 3 compatible yet, as I'm not 100% sure. I tested before and after this change and found a bug (unrelated to this change) where this script being loaded seems to prevent clean `/quit` of weechat. Since I've _only_ got Python 3 at the moment, that's where I've experienced it. I don't know whether it also currently happens with Python 2. I'll try to find some more time to figure it out, but it might take a while to get all the weechat scripting stuff back into my head again!

Since the issue I describe also happens with the existing version, I think it's still reasonable to consider merging this change.