### PR TITLE
New script emojize.py: emoji shortcodes to unicode :tada:

### DIFF
--- a/python/emojize.py
+++ b/python/emojize.py
@@ -7,7 +7,7 @@ It converts emoji shortcodes to Unicode emoji.
 This package is based on the emoji_aliases.py script by Mike Reinhardt.
 
 License: CC0
-Author: Thom Wiggers
+Author: Thom Wiggers <thom@thomwiggers.nl>
 Repository: https://github.com/thomwiggers/weechat-emojize
 
 This plugin supports python 3 and requires the 'emoji' python package.

--- a/python/emojize.py
+++ b/python/emojize.py
@@ -1,0 +1,77 @@
+"""
+Weechat plugin to convert emoji shortcodes to unicode emoji.
+
+This plugin is a thin wrapper around the emoji package for python.
+It converts emoji shortcodes to Unicode emoji.
+
+This package is based on the emoji_aliases.py script by Mike Reinhardt.
+
+License: CC0
+Author: Thom Wiggers
+Repository: https://github.com/thomwiggers/weechat-emojize
+
+This plugin supports python 3 and requires the 'emoji' python package.
+Requires at least weechat 1.3
+"""
+
+
+def register():
+    weechat.register(
+        "emojize",
+        "Thom Wiggers",
+        "1.0.0",
+        "CC0",
+        "Convert emoji shortcodes to unicode emoji",
+        "",  # shutdown function
+        "utf-8",
+    )
+
+
+import_ok = True
+
+try:
+    import emoji
+except ImportError:
+    print("Failed to import emoji package, try installing 'emoji'")
+    import_ok = False
+
+import weechat
+
+
+HOOKS = (
+    "away",
+    "cnotice",
+    "cprivmsg",
+    "kick",
+    "knock",
+    "notice",
+    "part",
+    "privmsg",
+    "quit",
+    "wallops",
+)
+
+
+def convert_emoji(_data, modifier, _modifier_data, string):
+    """Convert the emoji in event messages"""
+    # Check if this message has a segment we shouldn't touch.
+    msg = weechat.info_get_hashtable("irc_message_parse", {"message": string})
+    pos_text = int(msg["pos_text"])
+    if msg["text"] != "" and pos_text > 0:
+        return (
+            string[:pos_text]
+            + emoji.emojize(msg["text"], use_aliases=True)
+            + string[(pos_text + len(msg["text"])) :]
+        )
+
+    if modifier == "input_text_for_buffer":
+        return emoji.emojize(string, use_aliases=True)
+
+    return string
+
+
+if __name__ == "__main__" and import_ok:
+    register()
+    weechat.hook_modifier("input_text_for_buffer", "convert_emoji", "")
+    for hook in HOOKS:
+        weechat.hook_modifier("irc_in2_{}".format(hook), "convert_emoji", "")


### PR DESCRIPTION
## Script info

<!-- MANDATORY INFO: -->

- Script name:  emojize.py
- Version:  1.0.0

<!-- Optional: external dependencies (other than WeeChat and standard interpreter libraries) -->
- Requirements: 
    - emojis

<!-- Optional: fill only if you are sure that a specific WeeChat version is required -->
- Min WeeChat version:  1.3

<!-- Optional: tags for script (see list of tags on https://weechat.org/scripts/), new tags are allowed -->
- Script tags:  emoji, irc, py3

## Description

<!-- Describe the new script or your changes in a few sentences -->
Weechat plugin to convert emoji shortcodes to unicode emoji.

This plugin is a thin wrapper around the emoji package for python.
It converts emoji shortcodes to Unicode emoji.

This package is based on the emoji_aliases.py script by Mike Reinhardt.



## Checklist (new script)

<!-- To fill only if you are adding a new script -->

<!-- Please validate and check each item with "[x]" (see file Contributing.md) -->

- [x] Single commit, single file added
- [x] Commit message: `New script name.py: short description…`
- [x] No similar script already exists
- [x] Name: max 32 chars, only lower case letters, digits and underscores
- [x] Unique name, does not already exist in repository
- [x] No shebang on the first line
- [x] Comment in script with name/pseudo, e-mail and license
- [x] Only English in code/comments
- [x] Pure WeeChat API used, no extra API
- [x] Function `hook_process` is used for any blocking call
- [x] For Python script: works with Python 3 (Python 2 support is optional)

