### PR TITLE
chanmon.pl 2.7: Make tags configurable

### DIFF
--- a/perl/chanmon.pl
+++ b/perl/chanmon.pl
@@ -52,6 +52,10 @@
 #  Changes the amount of lines the output bar will hold.
 #  (Only appears once output has been set to bar, defaults to 10)
 #
+# /set plugins.var.perl.chanmon.tags
+#  A comma seperated list of tags. chanmon will only work on lines matching one of these tags
+#  (default: "irc_privmsg,irc_topic")
+#
 # /set plugins.var.perl.chanmon.nick_prefix
 # /set plugins.var.perl.chanmon.nick_suffix
 #  Sets the prefix and suffix chars in the chanmon buffer
@@ -73,6 +77,8 @@
 # Bugs and feature requests at: https://github.com/KenjiE20/chanmon
 
 # History:
+# 2021-04-13, Tobias Rehbein <tobias.rehbein@web.de>
+# 	v2.7: add configurable list of tags that chanmon should work on
 # 2020-06-21, Sebastien Helleu <flashcode@flashtux.org>:
 #	v2.6: make call to bar_new compatible with WeeChat >= 2.9
 # 2014-08-16, KenjiE20 <longbow@longbowslair.co.uk>:
@@ -235,6 +241,10 @@ Command wrapper for chanmon commands
 ".weechat::color("bold")."/set plugins.var.perl.chanmon.bar_lines".weechat::color("-bold")."
  Changes the amount of lines the output bar will hold.
  (Only appears once output has been set to bar, defaults to 10)
+
+".weechat::color("bold")."/set plugins.var.perl.chanmon.tags".weechat::color("-bold")."
+ A comma seperated list of tags. chanmon will only work on lines matching one of these tags
+ (default: \"irc_privmsg,irc_topic\")
 
 ".weechat::color("bold")."/set plugins.var.perl.chanmon.nick_prefix".weechat::color("-bold")."
 ".weechat::color("bold")."/set plugins.var.perl.chanmon.nick_suffix".weechat::color("-bold")."
@@ -595,6 +605,12 @@ sub chanmon_config_init
 		weechat::config_set_plugin("merge_private", "off");
 	}
 
+	# Messages to work on
+	if (!(weechat::config_is_set_plugin ("tags")))
+	{
+		weechat::config_set_plugin("tags", "irc_privmsg,irc_topic");
+	}
+
 	# Check for exisiting prefix/suffix chars, and setup accordingly
 	$prefix = weechat::config_get("irc.look.nick_prefix");
 	$prefix = weechat::config_string($prefix);
@@ -732,6 +748,9 @@ sub chanmon_new_message
 	my $window_displayed = "";
 	my $dyncheck = "0";
 
+	my @tags = split(/,/, weechat::config_get_plugin("tags"));
+	my $tag_matched = 0;
+
 #	DEBUG point
 #	$string = "\t"."0: ".$_[0]." 1: ".$_[1]." 2: ".$_[2]." 3: ".$_[3]." 4: ".$_[4]." 5: ".$_[5]." 6: ".$_[6]." 7: ".$_[7];
 #	weechat::print("", "\t".$string);
@@ -745,8 +764,17 @@ sub chanmon_new_message
 	$cb_prefix = $_[6];
 	$cb_msg = $_[7];
 
-	# Only work on messages and topic notices
-	if ($cb_tags =~ /irc_privmsg/ || $cb_tags =~ /irc_topic/)
+	# Only work on specific messages
+	foreach (@tags)
+	{
+		if ($cb_tags =~ $_)
+		{
+			$tag_matched = 1;
+			last;
+		}
+	}
+
+	if ($tag_matched)
 	{
 		# Check buffer name is an IRC channel or private message when enabled
 		$bufname = weechat::buffer_get_string($cb_bufferp, 'name');
@@ -1191,7 +1219,7 @@ sub format_buffer_name
 }
 
 # Check result of register, and attempt to behave in a sane manner
-if (!weechat::register("chanmon", "KenjiE20", "2.6", "GPL3", "Channel Monitor", "", ""))
+if (!weechat::register("chanmon", "KenjiE20", "2.7", "GPL3", "Channel Monitor", "", ""))
 {
 	# Double load
 	weechat::print ("", "\tChanmon is already loaded");


### PR DESCRIPTION
## Script info

<!-- MANDATORY INFO: -->

- Script name: chanmon.pl 
- Version: 2.7

## Description

This adds a new configuration for the tags that identify the messages the script should work on. The default value corresponds to the previous behavior.

Full disclosure: My knowledge of perl as a programming language is almost non-existent.

Example: If you are using the weechat-matrix script you might append `matrix_message` to the list of tags to let chanmon monitor matrix rooms.

## Checklist (script update)

- [ ] Author has been contacted - script seems to be unmaintained upstream, discussed via IRC
- [x] Single commit, single file added
- [x] Commit message format: `script_name.py X.Y: …`
- [x] Script version and Changelog have been updated
- [ ] For Python script: works with Python 3 (Python 2 support is optional)
