### PR TITLE
soju.py 0.1.1: eat BOUNCER messages

### DIFF
--- a/python/soju.py
+++ b/python/soju.py
@@ -5,7 +5,7 @@
 
 import weechat
 
-weechat.register("soju", "soju", "0.1.0", "AGPL3", "soju bouncer integration", "", "")
+weechat.register("soju", "soju", "0.1.1", "AGPL3", "soju bouncer integration", "", "")
 
 bouncer_cap = "soju.im/bouncer-networks"
 caps_option = weechat.config_get("irc.server_default.capabilities")
@@ -47,7 +47,7 @@ def handle_bouncer_msg(data, signal, signal_data):
     # Don't connect twice to the same network
     netid = args[1]
     if netid in added_networks:
-        return weechat.WEECHAT_RC_OK
+        return weechat.WEECHAT_RC_OK_EAT
 
     # Retrieve the network name from the attributes
     net_name = None
@@ -79,7 +79,7 @@ def handle_bouncer_msg(data, signal, signal_data):
     weechat.command(weechat.buffer_search("core", "weechat"), " ".join(add_server))
     weechat.command(weechat.buffer_search("core", "weechat"), "/connect " + net_name)
 
-    return weechat.WEECHAT_RC_OK
+    return weechat.WEECHAT_RC_OK_EAT
 
 weechat.hook_signal("*,irc_raw_in_376", "handle_isupport_end_msg", "") # RPL_ENDOFMOTD
 weechat.hook_signal("*,irc_raw_in_422", "handle_isupport_end_msg", "") # ERR_NOMOTD


### PR DESCRIPTION
These messages aren't recognized by WeeChat and display an error in
the server buffer. Eat the messages to suppress the error. Since
commit [1], this will make WeeChat ignore the messages. Before that
commit, WeeChat ignores the hook's return value.

[1]: https://github.com/weechat/weechat/commit/ff8beb1918816ccd1c15954f7f564ab02e9cfb9f

## Checklist (script update)

- [x] Author has been contacted
- [x] Single commit, single file added
- [x] Commit message format: `script_name.py X.Y: …`
- [x] Script version and Changelog have been updated
- [x] For Python script: works with Python 3 (Python 2 support is optional)