### PR TITLE
parse_relayed_msg.pl 1.9.6: fix nick parsing with messages containing @ and >

### DIFF
--- a/perl/parse_relayed_msg.pl
+++ b/perl/parse_relayed_msg.pl
@@ -8,6 +8,7 @@
 #
 # thanks to darrob for hard beta-testing
 #
+# 1.9.6: fix: nick parsing with messages containing @ and >
 # 1.9.5: add compatibility with matrix-appservice-irc
 # 1.9.4: add compatibility with other kind of messages than irc
 # 1.9.3: add compatibility with new weechat_print modifier data (WeeChat >= 2.9)
@@ -68,7 +69,7 @@
 
 use strict;
 my $SCRIPT_NAME         = "parse_relayed_msg";
-my $SCRIPT_VERSION      = "1.9.5";
+my $SCRIPT_VERSION      = "1.9.6";
 my $SCRIPT_DESCR        = "proper integration of remote users' nicknames in channel and nicklist";
 my $SCRIPT_AUTHOR       = "w8rabbit";
 my $SCRIPT_LICENCE      = "GPL3";
@@ -165,7 +166,7 @@ sub parse_relayed_msg_cb
         my $blacklist_raw = weechat::config_get_plugin("blacklist");
         @blacklist = split( /,/,$blacklist_raw);
         # message from muninn bot!
-        if ( $line =~ m/^<([^@]+)@([^>]+)\>\s(.+)$/ )
+        if ( $line =~ m/^<([^@>]+)@([^>]+)\>\s(.+)$/ )
         {
             my ($relaynick, $relaynet, $relaymsg) = ($1,$2,$3);
             if ( grep /^$servername.$relaynick$/, @blacklist )              # check for ignored relay nicks


### PR DESCRIPTION
## Script info

- Script name: `parse_relayed_msg.pl`
- Version: `1.9.6`

## Description

When a relayed message contains both an `@` and `>`, the "message from muninn bot" regex incorrectly parses everything up to the `>` following the `@` as the nickname, instead of the first occurrence of the `>` character.

For example when a bot would relay someone's message `"blub @ foo > test"`, I would see this being output as someone called `"nick> blub @ foo "` sending the message `"test"`.

This is a minimal fix that makes sure that the regex does not match when a `>` precedes the matched `@` symbol.

Fixes #382.

## Checklist (script update)

- [x] ~~Author has been contacted~~ Could not be contacted (email could not be delivered)
- [x] Single commit, single file added
- [x] Commit message format: `script_name.py X.Y: …`
- [x] Script version and Changelog have been updated
- [x] ~~For Python script: works with Python 3 (Python 2 support is optional)~~