### PR TITLE
Rename queue.py to cmdqueue.py

### DIFF
--- a/python/cmdqueue.py
+++ b/python/cmdqueue.py
@@ -1,5 +1,5 @@
 # ==================================================== #
-# Script Name: queue.py	
+# Script Name: cmdqueue.py
 # Script Author: walk <KingPython@gmx.com>
 # Script Purpose: Command queing at its finest. Hopefully.
 #
@@ -162,7 +162,7 @@ class Queue():
 			return False
 
 
-SCRIPT_NAME		= "queue"
+SCRIPT_NAME		= "cmdqueue"
 SCRIPT_AUTHOR	= "walk"
 SCRIPT_VERSION	= "0.4.3"
 SCRIPT_LICENSE	= "GPL3"


### PR DESCRIPTION
Python 3 provides a queue.py so the name is reserved.

If an other scripts does an `import queue` weechat will log:
python: script "queue" already registered (register ignored)
python: unable to register script "queue" (another script already exists with this name)

Ref.: https://bugs.launchpad.net/ubuntu/+source/weechat-scripts/+bug/1903354