### PR TITLE
unwanted_msg.py 0.3: remove leading whitespace in every situation

### DIFF
--- a/python/unwanted_msg.py
+++ b/python/unwanted_msg.py
@@ -13,19 +13,21 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
+# along with this program. If not, see <http://wwweechat.gnu.org/licenses/>.
 #
 # This script checks every message before it is sent and blocks messages which
 # correspond to misformatted commands (e.g. " /msg NickServ…") to avoid the
 # unfortunate discosure of personnal informations.
 #
+# 2021-09-11: Kevin Morris <kevr@cost.org>
+#        0.3: remove leading whitespaces in all situations
 # 2018-06-07: nils_2@freenode.#weechat
 #        0.2: make script compatible with Python 3.x
 # 2012-03-07: nesthib <nesthib@gmail.com>
 #        0.1: initial release
 
 try:
-    import weechat as w
+    import weechat
 except Exception:
     print("This script must be run under WeeChat.")
     print("Get WeeChat now at: https://weechat.org")
@@ -35,54 +37,91 @@ import re
 
 name = "unwanted_msg"
 author = "nesthib <nesthib@gmail.com>"
-version = "0.2"
+version = "0.3"
 license = "GPL"
-description = "Avoid sending misformatted commands as messages"
+description = "Avoid sending misformatted messages"
 shutdown_function = ""
 charset = ""
 
-w.register(name, author, version, license, description, shutdown_function, charset)
+config = {
+    "left_delimiter": "[",
+    "right_delimiter": "]"
+}
 
-settings = {
-        'regexp'        : ' +/',     # if the pattern matches the beginning of the line, the message will be blocked
-        'warning_buffer': 'current', # if set to current/server/weechat will print warning on current/server/weechat buffer. Disable warning if unset
-        }
-for opt, val in settings.items():
-    if not w.config_is_set_plugin(opt):
-        w.config_set_plugin(opt, val)
+weechat.register(name, author, version, license,
+                 description, shutdown_function, charset)
 
-def my_modifier_cb(data, modifier, modifier_data, string):
-    if unwanted_pattern.match(string):
-        if options['warning_buffer'] == 'current':
-            output = w.current_buffer()
-        elif options['warning_buffer'] == 'server':
-            server = w.buffer_get_string(w.current_buffer(), 'localvar_server')
-            plugin = w.buffer_get_string(w.current_buffer(), 'plugin')
-            output = w.buffer_search(plugin, 'server.'+server)
-        elif options['warning_buffer'] == '':
-            output = None
-        else:
-            output = '' # if invalid option set to weechat buffer
-        if not output == None:
-            w.prnt_date_tags(output, 0, 'no_log', '%sunwanted message deleted: "%s"' % (w.prefix('error'), string))
-        w.buffer_set(w.current_buffer(), 'input', string)
-        return ''
-    else:
-        return string
 
-options = {}
-for option in settings.keys():
-    options[option] = w.config_get_plugin(option)
-unwanted_pattern = re.compile(options['regexp'])
+def raw_command_cb(data, buffer, args):
+    """ Implementation of the /raw command.
 
-def my_config_cb(data, option, value):
-    global options, unwanted_pattern
-    for option in settings.keys():
-        options[option] = w.config_get_plugin(option)
-    unwanted_pattern = re.compile(options['regexp'])
-    return w.WEECHAT_RC_OK
+    /raw sends arguments given as verbatim as possible to the buffer.
+    Commands themselves remove whitespace found between the command and
+    any arguments, and so, a special delimiter is required to decipher
+    what the user intends when formatting inputs with included
+    whitespace: [ some message].
 
-for option in settings.keys():
-    w.hook_config("plugins.var.python.%s.%s" % (name, option), "my_config_cb", "")
 
-w.hook_modifier('input_text_for_buffer', 'my_modifier_cb', '')
+    Example output:
+        /raw  hello
+            "hello"
+        /raw [ hello]
+            " hello"
+    """
+    left = weechat.config_get_plugin("left_delimiter")
+    right = weechat.config_get_plugin("right_delimiter")
+    weechat.command(buffer, args.lstrip(left).rstrip(right))
+    return weechat.WEECHAT_RC_OK
+
+
+def my_modifier_cb(buf, modifier, modifier_data, string):
+    if re.match(r'^\s.+$', string):
+        # In the case where there actually is whitespace and we need to
+        # deal with it, reset the input position to 0. We are only
+        # dealing with the beginning of the string, so this has no
+        # negative side affects. Without this, space causes the cursor
+        # position to increment when attempting to type a whitespace
+        # at the beginning of an otherwise-not-lead-with-whitespace string.
+        weechat.buffer_set(modifier_data, "input_pos", "0")
+    return string.lstrip()  # Remove _any_ whitespace at the start.
+
+
+def get_left_delimiter():
+    return weechat.config_get_plugin("left_delimiter")
+
+
+def get_right_delimiter():
+    return weechat.config_get_plugin("right_delimiter")
+
+
+def get_usage():
+    """ A dynamic function that produces usage based on the plugin's
+    left_delimiter and right_delimiter options. """
+    return get_left_delimiter() + " raw-text" + get_right_delimiter()
+
+
+if __name__ == "__main__":
+    for option, default_value in config.items():
+        is_set = weechat.config_is_set_plugin(option)
+        if not is_set:
+            weechat.config_set_plugin(option, default_value)
+
+    desc = f"""Send raw input (including whitespace in enclosed configured \
+delimiters) to the current buffer.
+
+Optional whitespace delimiters can be configured:
+
+    plugins.var.python.{name}.left_delimiter
+        - default: [
+        - configured: {get_left_delimiter()}
+
+    plugins.var.python.{name}.right_delimiter
+        - default: ]
+        - configured: {get_right_delimiter()}
+
+Execute '/python reload unwanted_msg' to reflect configuration changes.
+"""
+
+    weechat.hook_modifier("input_text_content", "my_modifier_cb", str())
+    weechat.hook_command("raw", desc, get_usage(), "", str(),
+                         "raw_command_cb", str())


### PR DESCRIPTION
Previously, this script was taking care of removing invalid spaces
used before a command. This patch improves the script to remove
leading whitespace characters in all cases, not just for a command.

Warnings have been removed with this commit. It merely does not allow
you to add leading whitespace into the input buffer, which feels
quite self-explanatory as a user (I think?).

Signed-off-by: Kevin Morris <kevr@0cost.org>

## Script info

<!-- MANDATORY INFO: -->

- Script name: `unwanted_msg.py`
- Version: `0.3`

## Description

Previously, `unwanted_msg.py` took care of dealing with spaces being entered in before
a command's `/` character. This update morphs the script into the same thought process
for **all** messages typed into the input buffer and includes all whitespace types (previously,
only spaces were dealt with).

## Checklist (script update)

- [x] Author has been contacted - **NOTE** The author has not been active for >= 1000 days.
- [x] Single commit, single file added
- [x] Commit message format: `script_name.py X.Y: …`
- [x] Script version and Changelog have been updated
- [x] For Python script: works with Python 3 (Python 2 support is optional)
- [x] Score 100 / 100 displayed by [weechat-script-lint](https://github.com/weechat/weechat-script-lint)