### PR TITLE
soju.py 0.1.5: adapt all username settings

### DIFF
--- a/python/soju.py
+++ b/python/soju.py
@@ -5,7 +5,7 @@
 
 import weechat
 
-weechat.register("soju", "soju", "0.1.4", "AGPL3", "soju bouncer integration", "", "")
+weechat.register("soju", "soju", "0.1.5", "AGPL3", "soju bouncer integration", "", "")
 
 bouncer_cap = "soju.im/bouncer-networks"
 caps_option = weechat.config_get("irc.server_default.capabilities")
@@ -87,9 +87,6 @@ def handle_bouncer_msg(data, signal, signal_data):
     net_name = "".join(ch if check_char(ch) else "_" for ch in net_name)
 
     addr = weechat.config_string(weechat.config_get("irc.server." + server_name + ".addresses"))
-    username = weechat.config_string(weechat.config_get("irc.server." + server_name + ".username"))
-    if "/" in username:
-        username = username.split("/")[0]
     add_server = [
         "/server",
         "add",
@@ -97,10 +94,17 @@ def handle_bouncer_msg(data, signal, signal_data):
         addr,
         "-temp",
         "-ssl",
-        "-username=" + username + "/" + net_name,
     ]
 
-    for k in ["password", "sasl_mechanism", "sasl_username", "sasl_password"]:
+    # User name settings need to be adapted for new networks
+    for k in ["username", "sasl_username"]:
+        v = weechat.config_string(weechat.config_get("irc.server." + server_name + "." + k))
+        if not v:
+            continue
+        username = v.split("/", maxsplit=1)[0] + "/" + net_name
+        add_server.append("-" + k + "=" + username)
+
+    for k in ["password", "sasl_mechanism", "sasl_password"]:
         v = weechat.config_string(weechat.config_get("irc.server." + server_name + "." + k))
         add_server.append("-" + k + "=" + v)
 


### PR DESCRIPTION
## Script info

- Script name: soju.py
- Version: 0.1.5

## Description

1. Correctly slices and dices usernames that contain `@client` suffix. `user@client` becomes `user/network@client` for the generated connections.
2. Applies the same handling to `sasl_username` parameter.

## Checklist (script update)

<!-- Please validate and check each item with "[x]" (see file Contributing.md) -->

- [x] Author has been contacted
- [x] Single commit, single file added
- [x] Commit message format: `script_name.py X.Y: …`
- [x] Script version and Changelog have been updated
- [x] For Python script: works with Python 3 (Python 2 support is optional)
- [x] Score 100 / 100 displayed by [weechat-script-lint](https://github.com/weechat/weechat-script-lint)

---
cc @emersion for review :)