### PR TITLE
zncplayback.py 0.2.2: handle invalid json in SCRIPT_SAVEFILE

### DIFF
--- a/python/zncplayback.py
+++ b/python/zncplayback.py
@@ -27,6 +27,8 @@
 #
 # History:
 #
+# 2022-02-02, Andreas Hackl <a@r0.at>:
+#     v0.2.2: handle invalid json in SCRIPT_SAVEFILE
 # 2021-05-06, Sébastien Helleu <flashcode@flashtux.org>:
 #     v0.2.1: add compatibility with WeeChat >= 3.2 (XDG directories)
 # 2019-07-09, Alyssa Ross <hi@alyssa.is>:
@@ -38,7 +40,7 @@ from __future__ import print_function
 
 SCRIPT_NAME = "zncplayback"
 SCRIPT_AUTHOR = "jazzpi"
-SCRIPT_VERSION = "0.2.1"
+SCRIPT_VERSION = "0.2.2"
 SCRIPT_LICENSE = "GPL3"
 SCRIPT_DESCRIPTION = "Add support for the ZNC Playback module"
 
@@ -86,12 +88,12 @@ def write_last_times():
 def read_last_times():
     """Read the last message times of all servers from disk."""
     global zncplayback_last_times
-    if not path.exists(SCRIPT_SAVEFILE):
+    try:
+        with open(SCRIPT_SAVEFILE, "r") as fh:
+            zncplayback_last_times = json.load(fh)
+    except (json.decoder.JSONDecodeError,FileNotFoundError):
         for server in zncplayback_settings["servers"].split(","):
             zncplayback_last_times[server] = 0
-        return
-    with open(SCRIPT_SAVEFILE, "r") as fh:
-        zncplayback_last_times = json.load(fh)
 
 
 def zncplayback_config_cb(data, option, value):


### PR DESCRIPTION


## Script info

<!-- MANDATORY INFO: -->

- Script name: zncplayback.py
- Version: 0.2.2

## Description

I somehow ended up with a 0 Byte SCRIPT_SAVEFILE, which made json.load()
throw an exception, which made the plugin do nothing at all. This fixes that kind of
problem.

Lint score is actually 99/100, but only because of the www.weechat.org vs weechat.org thing, which kind of doesn't belong in this PR.

<!-- To fill only if you are updating an existing script -->

<!-- Please validate and check each item with "[x]" (see file Contributing.md) -->

- [x] Author has been contacted
- [x] Single commit, single file added
- [x] Commit message format: `script_name.py X.Y: …`
- [x] Script version and Changelog have been updated
- [x] For Python script: works with Python 3 (Python 2 support is optional)
- [ ] Score 100 / 100 displayed by [weechat-script-lint](https://github.com/weechat/weechat-script-lint)
