### PR TITLE
go.py: use buf number instead of name

### DIFF
--- a/python/go.py
+++ b/python/go.py
@@ -294,11 +294,11 @@ def go_now(buf, args):
         for index in range(len(listbuf)):
             if go_match_beginning(listbuf[index], args):
                 weechat.command(buf,
-                                '/buffer ' + str(listbuf[index]['full_name']))
+                                '/buffer ' + str(listbuf[index]['number']))
                 return
 
     # jump to first buffer in matching buffers by default
-    weechat.command(buf, '/buffer ' + str(listbuf[0]['full_name']))
+    weechat.command(buf, '/buffer ' + str(listbuf[0]['number']))
 
 
 def go_cmd(data, buf, args):
@@ -515,7 +515,7 @@ def go_command_run_input(data, buf, command):
         go_end(buf)
         if len(buffers) > 0:
             weechat.command(
-                buf, '/buffer ' + str(buffers[buffers_pos]['full_name']))
+                buf, '/buffer ' + str(buffers[buffers_pos]['number']))
         return weechat.WEECHAT_RC_OK_EAT
     return weechat.WEECHAT_RC_OK
 


### PR DESCRIPTION


## Script info

<!-- MANDATORY INFO: -->

- Script name: go.py 
- Version: 

<!-- Optional: external dependencies (other than WeeChat and standard interpreter libraries) -->
- Requirements: 

<!-- Optional: fill only if you are sure that a specific WeeChat version is required -->
- Min WeeChat version: 

<!-- Optional: tags for script (see list of tags on https://weechat.org/scripts/), new tags are allowed -->
- Script tags: 

## Description

This fixes some issues when switching to a buffer, when the buffer's
name is something that weechat does not like, e.g. "#Foo < Bar"

    weechat =!= Error with command "/buffer #Foo < Bar" (help on command: /help buffer)

These aren't really valid channel names(I think?), but some weechat
plugins (weechat-matrix) may create buffers with incompatible names like
that. In any case, switching based on the buffer *number* seems to be a
reliable compromise.