### PR TITLE
autojoin_on_invite.py 0.9: Fix nick regex

### DIFF
--- a/python/autojoin_on_invite.py
+++ b/python/autojoin_on_invite.py
@@ -20,6 +20,8 @@
 # (this script requires WeeChat 0.3.0 or newer)
 #
 # History:
+# 2022-10-19, Guillermo Castro <github@codegeek.dev>
+#   version 0.9: fix regex parsing of INVITE to allow non-ircv3 matching
 # 2022-03-2, h-0-s-h <noreply@ic3.gov>
 #   version 0.8: fix reged parsing of INVITE message to account for ircv3/CAPS style/etc
 #                (@time=2022-03-02T19:00:30.041Z :XXXXX!~XXXXX@xxxxx INVITE h-0-s-h :#xxxxx)
@@ -47,7 +49,7 @@ import re
 
 SCRIPT_NAME    = "autojoin_on_invite"
 SCRIPT_AUTHOR  = "xt <xt@bash.no>"
-SCRIPT_VERSION = "0.8"
+SCRIPT_VERSION = "0.9"
 SCRIPT_LICENSE = "GPL3"
 SCRIPT_DESC    = "Auto joins channels when invited"
 
@@ -90,7 +92,7 @@ def invite_cb(data, signal, signal_data):
     server = signal.split(',')[0] # EFNet,irc_in_INVITE
     channel = signal_data.split()[-1].lstrip(':') # :nick!ident@host.name INVITE yournick :#channel
     from_nick = ''
-    SearchStr = ':.*\:(?P<nick>.+)!' #@time=2022-03-02T19:00:30.041Z :XX-XXXX!~XX-XXXX@xx.xxxx INVITE yournick :#xxxx-xxx
+    SearchStr = '(?:\@.*)?:(?P<nick>.+)!' #@time=2022-03-02T19:00:30.041Z :XX-XXXX!~XX-XXXX@xx.xxxx INVITE yournick :#xxxx-xxx (works also when no message-tag is present)
     from_nick = re.search(SearchStr, signal_data).groups()[0]
 
     if len(w.config_get_plugin('whitelist_nicks')) > 0 and len(w.config_get_plugin('whitelist_channels')) > 0: # if there's two whitelists, accept both


### PR DESCRIPTION
## Script info

<!-- MANDATORY INFO: -->

- Script name: autojoin_on_invite.py
- Version: 0.9

<!-- Optional: external dependencies (other than WeeChat and standard interpreter libraries) -->
- Requirements: 

<!-- Optional: fill only if you are sure that a specific WeeChat version is required -->
- Min WeeChat version: 

<!-- Optional: tags for script (see list of tags on https://weechat.org/scripts/), new tags are allowed -->
- Script tags: 

## Description

<!-- Describe the new script or your changes in a few sentences -->
Fixed regex for nick parsing when the server doesn't have message tags (it was throwing an error):

11:48:22 python: stdout/stderr (autojoin_on_invite): Traceback (most recent call last):
11:48:22 python: stdout/stderr (autojoin_on_invite):   File "/home/codegeek/.local/share/weechat/python/autoload/autojoin_on_invite.py", line 94, in invite_cb
11:48:22 python: stdout/stderr (autojoin_on_invite):     from_nick = re.search(SearchStr, signal_data).groups()[0]
11:48:22 python: stdout/stderr (autojoin_on_invite): AttributeError: 'NoneType' object has no attribute 'groups'
11:48:22 =!= python: error in function "invite_cb"

## Checklist (script update)

<!-- To fill only if you are updating an existing script -->

<!-- Please validate and check each item with "[x]" (see file Contributing.md) -->

- [ ] Author has been contacted (No reply from the author after 24 hours)
- [x] Single commit, single file added
- [x] Commit message format: `script_name.py X.Y: …`
- [x] Script version and Changelog have been updated
- [x] For Python script: works with Python 3 (Python 2 support is optional)
- [x] Score 100 / 100 displayed by [weechat-script-lint](https://github.com/weechat/weechat-script-lint)