### PR TITLE
colorize_nicks.py 30: added "[:,]" to VALID_NICK

### DIFF
--- a/python/colorize_nicks.py
+++ b/python/colorize_nicks.py
@@ -21,6 +21,9 @@
 #
 #
 # History:
+# 2022-11-07: mva
+#   version 30: add ":" and "," to VALID_NICK regexp,
+#               to don't reset colorization in input_line
 # 2022-07-11: ncfavier
 #   version 29: check nick for exclusion *after* stripping
 #               decrease minimum min_nick_length to 1
@@ -93,13 +96,13 @@ w = weechat
 
 SCRIPT_NAME    = "colorize_nicks"
 SCRIPT_AUTHOR  = "xt <xt@bash.no>"
-SCRIPT_VERSION = "29"
+SCRIPT_VERSION = "30"
 SCRIPT_LICENSE = "GPL"
 SCRIPT_DESC    = "Use the weechat nick colors in the chat area"
 
 # Based on the recommendations in RFC 7613. A valid nick is composed
 # of anything but " ,*?.!@".
-VALID_NICK = r'([@~&!%+-])?([^\s,\*?\.!@]+)'
+VALID_NICK = r'([@~&!%+-])?([^\s,\*?\.!@:,]+)'
 valid_nick_re = re.compile(VALID_NICK)
 ignore_channels = []
 ignore_nicks = []


### PR DESCRIPTION

## Script info

<!-- MANDATORY INFO: -->

- Script name: colorize_nicks.py
- Version: 30

## Description

<!-- Describe the new script or your changes in a few sentences -->

I've added ":" and "," to VALID_NICK regexp.
The point is to don't reset the colorization in input_line when you address someone by nick (like `FlashCode:` or `FlachCode,`).



## Checklist (script update)

<!-- To fill only if you are updating an existing script -->

<!-- Please validate and check each item with "[x]" (see file Contributing.md) -->

- [ ] Author has been contacted
- [x] Single commit, single file added
- [x] Commit message format: `script_name.py X.Y: …`
- [x] Script version and Changelog have been updated
- [x] For Python script: works with Python 3 (Python 2 support is optional)
- [ ] Score 100 / 100 displayed by [weechat-script-lint](https://github.com/weechat/weechat-script-lint)

