### PR TITLE
openbsd_privdrop.py 0.1.1: sane defaults for unveil

### DIFF
--- a/python/openbsd_privdrop.py
+++ b/python/openbsd_privdrop.py
@@ -30,6 +30,9 @@
 
 # History:
 #
+# 2022-11-09, Alvar Penning <post@0x21.biz>
+#   version 0.1.1: sane defaults for unveil
+#
 # 2022-09-18, Alvar Penning <post@0x21.biz>
 #   version 0.1.0: initial release
 
@@ -42,7 +45,7 @@ import weechat
 
 SCRIPT_NAME    = "openbsd_privdrop"
 SCRIPT_AUTHOR  = "Alvar Penning <post@0x21.biz>"
-SCRIPT_VERSION = "0.1.0"
+SCRIPT_VERSION = "0.1.1"
 SCRIPT_LICENSE = "ISC"
 SCRIPT_DESC    = "Drop WeeChat's privileges through OpenBSD's pledge(2) and unveil(2)."
 
@@ -56,7 +59,18 @@ SETTINGS = {
             "List of promises to executed processes; requires exec in pledge_promises.",
             ),
         "unveil": (
-            "~:rwc;/home:r;/usr/local/lib:r",  # WeeChat `stat`s /home while building the path to /home/$USER/...
+            ";".join([
+                # Full read/write access (no exec!) to the user's home directory.
+                # This may be tightened, especially if WeeChat is not run as a separate user.
+                "~:rwc",
+                # WeeChat `stat`s /home while building the path to /home/$USER/...
+                # Might be changed if the home directory lies somehwere else.
+                "/home:r",
+                # Other scripts might load some library or a third-party Python modules later.
+                "/usr/local/lib:r",
+                # Necessary for HTTPS validation, e.g., when downloading WeeChat scripts.
+                "/etc/ssl/cert.pem:r",
+                ]),
             "List of path and permissions for unveil(2). Format: /a/path:rwc;/another/path:rw",
             ),
 }


### PR DESCRIPTION
## Script info

<!-- MANDATORY INFO: -->

- Script name: openbsd_privdrop.py
- Version: 0.1.1

## Description

<!-- Describe the new script or your changes in a few sentences -->
> version 0.1.1: sane defaults for unveil

Prior to this change, the `unveil(2)` system call enforced a very harsh filter by default. This led, for example, to the situation that external scripts could not be installed. This change now allows this and has been tested out by me for over a month so far.


## Checklist (script update)

<!-- To fill only if you are updating an existing script -->

<!-- Please validate and check each item with "[x]" (see file Contributing.md) -->

- [x] Author has been contacted
- [x] Single commit, single file added
- [x] Commit message format: `script_name.py X.Y: …`
- [x] Script version and Changelog have been updated
- [x] For Python script: works with Python 3 (Python 2 support is optional)
- [x] Score 100 / 100 displayed by [weechat-script-lint](https://github.com/weechat/weechat-script-lint)