### PR TITLE
urlgrab.py: Use xdg-open as default local command

### DIFF
--- a/python/urlgrab.py
+++ b/python/urlgrab.py
@@ -39,7 +39,7 @@
 #   localcmd
 #     The command to run on the local host to launch URLs in 'local' mode.
 #     The string '%s' will be replaced with the URL.  The default is
-#     'firefox %s'.
+#     'xdg-open %s'.
 #
 #   remotessh
 #     The command (and arguments) used to connect to the remote host for
@@ -53,9 +53,9 @@
 #
 #   remotecmd
 #     The command to execute on the remote host for 'remote' mode.  The
-#     default is 'bash -c "DISPLAY=:0.0 firefox '%s'"'  Which runs bash, sets
+#     default is 'bash -c "DISPLAY=:0.0 xdg-open '%s'"'  Which runs bash, sets
 #     up the environment to display on the remote host's main X display,
-#     and runs firefox.  As with 'localcmd', the string '%s' will be
+#     and runs the default browser.  As with 'localcmd', the string '%s' will be
 #     replaced with the URL.
 #
 #   cmdoutput
@@ -133,6 +133,8 @@
 #           - Fix python 3 compatibility (replace "has_key" by "in")
 #  - V3.1 Ron Alleva <ron.alleva@gmail.com>:
 #           - Add 'use_full_name' setting, to allow storing URLs by full name of buffer
+#  - V3.2 Marco Trevisan <mail@3v1n0.net>:
+#           - Use xdg-open as default 'localcmd'
 #
 # Copyright (C) 2005 David Rubin <drubin AT smartcube dot co dot za>
 #
@@ -185,7 +187,7 @@ urlRe = re.compile(r'(\w+://(?:%s|%s)(?::\d+)?(?:/[^\]>\s]*)?)' % (domain, ipAdd
 
 SCRIPT_NAME    = "urlgrab"
 SCRIPT_AUTHOR  = "David Rubin <drubin [At] smartcube [dot] co [dot] za>"
-SCRIPT_VERSION = "3.1"
+SCRIPT_VERSION = "3.2"
 SCRIPT_LICENSE = "GPL"
 SCRIPT_DESC    = "Url functionality Loggin, opening of browser, selectable links"
 CONFIG_FILE_NAME= "urlgrab"
@@ -300,9 +302,9 @@ class UrlGrabSettings(UserDict):
         self.data['localcmd']=weechat.config_new_option(
             self.config_file, section_default,
             "localcmd", "string", """Local command to execute""", "", 0, 0,
-            "firefox '%s'", "firefox '%s'", 0, "", "", "", "", "", "")
+            "xdg-open '%s'", "xdg-open '%s'", 0, "", "", "", "", "", "")
 
-        remotecmd="ssh -x localhost -i ~/.ssh/id_rsa -C \"export DISPLAY=\":0.0\" &&  firefox '%s'\""
+        remotecmd="ssh -x localhost -i ~/.ssh/id_rsa -C \"export DISPLAY=\":0.0\" && xdg-open '%s'\""
         self.data['remotecmd']=weechat.config_new_option(
             self.config_file, section_default,
             "remotecmd", "string", remotecmd, "", 0, 0,


### PR DESCRIPTION
## Script info

<!-- MANDATORY INFO: -->

- Script name: `urlgrab.py`
- Version: 3.2

## Description

It will automatically open the URI in the default browser for the system, without having users to change it to their browser.

## Checklist (script update)

<!-- To fill only if you are updating an existing script -->

<!-- Please validate and check each item with "[x]" (see file Contributing.md) -->

- [ ] Author has been contacted
- [x] Single commit, single file added
- [x] Commit message format: `script_name.py X.Y: …`
- [x] Script version and Changelog have been updated
- [ ] For Python script: works with Python 3 (Python 2 support is optional)
- [x] Score 100 / 100 displayed by [weechat-script-lint](https://github.com/weechat/weechat-script-lint)
