### PR TITLE
fish 0.15: fix encoding errors with message markers

### DIFF
--- a/python/fish.py
+++ b/python/fish.py
@@ -61,7 +61,7 @@ from os import urandom
 
 SCRIPT_NAME = "fish"
 SCRIPT_AUTHOR = "David Flatz <david@upcs.at>"
-SCRIPT_VERSION = "0.14"
+SCRIPT_VERSION = "0.15"
 SCRIPT_LICENSE = "GPL3"
 SCRIPT_DESC = "FiSH for weechat"
 CONFIG_FILE_NAME = SCRIPT_NAME
@@ -894,7 +894,7 @@ def fish_modifier_input_text(data, modifier, server_name, string):
     targetl = target.lower()
     if targetl not in fish_keys:
         return string
-    return "%s" % (fish_msg_w_marker(string))
+    return "%s" % (fish_msg_w_marker(string.encode()).decode())
 
 
 def fish_unload_cb():
@@ -1139,11 +1139,11 @@ def fish_list_keys(buffer):
 
 
 def fish_msg_w_marker(msg):
-    marker = weechat.config_string(fish_config_option["mark_encrypted"])
+    marker = weechat.config_string(fish_config_option["mark_encrypted"]).encode()
     if weechat.config_string(fish_config_option["mark_position"]) == "end":
-        return "%s%s" % (msg, marker)
+        return b"%s%s" % (msg, marker)
     elif weechat.config_string(fish_config_option["mark_position"]) == "begin":
-        return "%s%s" % (marker, msg)
+        return b"%s%s" % (marker, msg)
     else:
         return msg
 


### PR DESCRIPTION
## Script info

<!-- MANDATORY INFO: -->

- Script name: fish.py
- Version: 0.15

## Description

- fix encoding errors with message markers (provided by @andkem)

## Checklist (script update)

<!-- To fill only if you are updating an existing script -->

<!-- Please validate and check each item with "[x]" (see file Contributing.md) -->

- [X] Author has been contacted
- [X] Single commit, single file added
- [X] Commit message format: `script_name.py X.Y: …`
- [X] Script version and Changelog have been updated
- [X] For Python script: works with Python 3 (Python 2 support is optional)
- [ ] Score 100 / 100 displayed by [weechat-script-lint](https://github.com/weechat/weechat-script-lint)