### PR TITLE
Update autosort.py to 3.10.

### DIFF
--- a/python/autosort.py
+++ b/python/autosort.py
@@ -25,6 +25,8 @@
 
 #
 # Changelog:
+# 3.10:
+#   * Fix exception in `/autosort helpers swap`.
 # 3.9:
 #   * Remove `buffers.pl` from recommended settings.
 # 3,8:
@@ -87,7 +89,7 @@ import weechat
 
 SCRIPT_NAME     = 'autosort'
 SCRIPT_AUTHOR   = 'Maarten de Vries <maarten@de-vri.es>'
-SCRIPT_VERSION  = '3.9'
+SCRIPT_VERSION  = '3.10'
 SCRIPT_LICENSE  = 'GPL3'
 SCRIPT_DESC     = 'Flexible automatic (or manual) buffer sorting based on eval expressions.'
 
@@ -616,7 +618,6 @@ def command_helper_swap(buffer, command, args):
 	except KeyError as e:
 		raise HumanReadableError('No such helper: {0}'.format(e.args[0]))
 
-	config.helpers.swap(index_a, index_b)
 	config.save_helpers()
 	command_helper_list(buffer, command, '')
 	return weechat.WEECHAT_RC_OK
@@ -829,7 +830,7 @@ def on_autosort_command(data, buffer, args):
 
 def add_completions(completion, words):
 	for word in words:
-		weechat.hook_completion_list_add(completion, word, 0, weechat.WEECHAT_LIST_POS_END)
+		weechat.completion_list_add(completion, word, 0, weechat.WEECHAT_LIST_POS_END)
 
 def autosort_complete_rules(words, completion):
 	if len(words) == 0:
@@ -1001,14 +1002,14 @@ If you remove all signals you can still sort your buffers manually with the
 
 {*white}# Recommended settings
 For the best visual effect, consider setting the following options:
-  {*white}/set {cyan}irc.look.server_buffer{reset} {brown}independent{reset}
+{*white}/set {cyan}irc.look.server_buffer{reset} {brown}independent{reset}
 
 This setting allows server buffers to be sorted independently, which is
 needed to create a hierarchical tree view of the server and channel buffers.
 
 If you are using the {*default}buflist{reset} plugin you can (ab)use Unicode to draw a tree
 structure with the following setting (modify to suit your need):
-  {*white}/set {cyan}buflist.format.indent {brown}"${{color:237}}${{if:${{buffer.next_buffer.local_variables.type}}=~^(channel|private)$?├─:└─}}"{reset}
+{*white}/set {cyan}buflist.format.indent {brown}"${{color:237}}${{if:${{buffer.next_buffer.local_variables.type}}=~^(channel|private)$?├─:└─}}"{reset}
 '''
 
 command_completion = '%(plugin_autosort) %(plugin_autosort) %(plugin_autosort) %(plugin_autosort) %(plugin_autosort)'


### PR DESCRIPTION
## Script info
- Script name: autosort.py
- Version: 3.10

## Description

Fixes an exception in the command `/autosort helpers swap`.

Also replaces the deprecated `hook_completion_list_add` with `completion_list_add` and fixes a false positive lint about mixed indentation.

## Checklist (script update)

- [x] Author has been contacted
- [x] Single commit, single file added
- [x] Commit message format: `script_name.py X.Y: …`
- [x] Script version and Changelog have been updated
- [x] For Python script: works with Python 3 (Python 2 support is optional)
- [x] Score 100 / 100 displayed by [weechat-script-lint](https://github.com/weechat/weechat-script-lint)
