### PR TITLE
openbsd_privdrop.py 0.1.2: add fattr to pledge_promises

### DIFF
--- a/python/openbsd_privdrop.py
+++ b/python/openbsd_privdrop.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Alvar Penning <post@0x21.biz>
+# Copyright (c) 2022, 2024 Alvar Penning <post@0x21.biz>
 #
 # Permission to use, copy, modify, and distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above
@@ -27,8 +27,16 @@
 #
 # - https://man.openbsd.org/pledge.2
 # - https://man.openbsd.org/unveil.2
+#
+# The config options for the SETTINGS below are:
+# - plugins.var.python.openbsd_privdrop.pledge_promises
+# - plugins.var.python.openbsd_privdrop.pledge_execpromises
+# - plugins.var.python.openbsd_privdrop.unveil
 
 # History:
+#
+# 2024-08-19, Alvar Penning <post@0x21.biz>
+#   version 0.1.2: add fattr to pledge_promises and a bit more documentation
 #
 # 2022-11-09, Alvar Penning <post@0x21.biz>
 #   version 0.1.1: sane defaults for unveil
@@ -45,13 +53,13 @@ import weechat
 
 SCRIPT_NAME    = "openbsd_privdrop"
 SCRIPT_AUTHOR  = "Alvar Penning <post@0x21.biz>"
-SCRIPT_VERSION = "0.1.1"
+SCRIPT_VERSION = "0.1.2"
 SCRIPT_LICENSE = "ISC"
 SCRIPT_DESC    = "Drop WeeChat's privileges through OpenBSD's pledge(2) and unveil(2)."
 
 SETTINGS = {
         "pledge_promises": (
-            "stdio rpath wpath cpath dpath inet flock unix dns sendfd recvfd tty proc error",
+            "stdio rpath wpath cpath dpath inet fattr flock unix dns sendfd recvfd tty proc error",
             "List of promises for pledge(2).",
             ),
         "pledge_execpromises": (
@@ -64,7 +72,8 @@ SETTINGS = {
                 # This may be tightened, especially if WeeChat is not run as a separate user.
                 "~:rwc",
                 # WeeChat `stat`s /home while building the path to /home/$USER/...
-                # Might be changed if the home directory lies somehwere else.
+                # Might be changed if the home directory lies somewhere else.
+                # This  happens by weechat_mkdir_parents calls, e.g., from logger_create_directory.
                 "/home:r",
                 # Other scripts might load some library or a third-party Python modules later.
                 "/usr/local/lib:r",


### PR DESCRIPTION
## Script info

<!-- MANDATORY INFO: -->

- Script name: `openbsd_privdrop.py`
- Version: 0.1.1 -> 0.1.2

## Description

Since WeeChat 4.3.0, the return value of `chmod` is being checked[^0]. This revealed a too strict pledge promise, missing `fattr`.

As an additional change, the level of documentation was increased, including a remainder why read permissions on /home are necessary.

[^0]: https://github.com/weechat/weechat/commit/2423fdbf2d66d241c809f797f75afd65dff91568#diff-b08b83cf9b86fa0f5c4ca579554a7ba593a892fd143526210844a05701e57058

## Checklist (script update)

<!-- To fill only if you are updating an existing script -->

<!-- Please validate and check each item with "[x]" (see file Contributing.md) -->

- [x] Author has been contacted (_NOTE: I am the author_)
- [x] Single commit, single file added
- [x] Commit message format: `script_name.py X.Y: …`
- [x] Script version and Changelog have been updated
- [x] For Python script: works with Python 3 (Python 2 support is optional)
- [x] Score 100 / 100 displayed by [weechat-script-lint](https://github.com/weechat/weechat-script-lint)