### PR TITLE
New script irccloud_avatar_link.py: Add IRCCloud avatar image link to WHOIS output

### DIFF
--- a/python/irccloud_avatar_link.py
+++ b/python/irccloud_avatar_link.py
@@ -1,0 +1,46 @@
+#
+# Copyright (9) 2024 Jesse McDowell <jessemcd1@gmail.com>
+#
+# Add IRCCloud avatar image link to WHOIS output
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+# even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with this program. If not,
+# see <https://www.gnu.org/licenses/>.
+#
+# 2024-08-25: Jesse McDowell
+#     version 1.0: Initial release
+
+
+try:
+    import weechat
+    from weechat import WEECHAT_RC_OK
+    import_ok = True
+except ImportError:
+    print('This script must be run under WeeChat.')
+    import_ok = False
+
+import re
+
+def whois311_cb(data, signal, signal_data):
+    buffer = weechat.info_get("irc_buffer", signal.split(",")[0])
+
+    userid_text = signal_data.split(" ")[5 if signal_data[0] == "@" else 4]
+
+    userid_match = userid_expression.match(userid_text)
+    if userid_match is not None:
+        weechat.prnt(buffer, "Avatar image: https://static.irccloud-cdn.com/avatar-redirect/%s" % userid_match.groups()[0])
+
+    return WEECHAT_RC_OK
+
+if __name__ == '__main__' and import_ok:
+    weechat.register("irccloud_avatar_link", "Jesse McDowell", "1.0", "GPL3", "Add IRCCloud avatar image link to WHOIS details", "", "")
+    userid_expression = re.compile("^[us]id([0-9]+)$")
+
+    weechat.hook_signal("*,irc_in2_311", "whois311_cb", "")


### PR DESCRIPTION
## Script info
- Script name: irccloud_avatar_link.py
- Version: 1.0

- Requirements: 

- Min WeeChat version: 

- Script tags: 

## Description

IRCCloud allows users to upload an avatar image, which is visible to anyone with a compatible client. This script detects these special usernames and adds the image URL to the server buffer along with the rest of the WHOIS block.

The avatar feature is documented here: https://blog.irccloud.com/avatars/

## Checklist (new script)

<!-- Please validate and check each item with "[x]" (see file Contributing.md) -->

- [x] Single commit, single file added
- [x] Commit message: `New script name.py: short description…`
- [x] No similar script already exists
- [x] Name: max 32 chars, only lower case letters, digits and underscores
- [x] Unique name, does not already exist in repository
- [x] No shebang on the first line
- [x] Comment in script with name/pseudo, e-mail and license
- [x] Only English in code/comments
- [x] Pure WeeChat API used, no extra API
- [x] Function `hook_process` is used for any blocking call
- [x] For Python script: works with Python 3 (Python 2 support is optional)
- [x] Score 100 / 100 displayed by [weechat-script-lint](https://github.com/weechat/weechat-script-lint)
