### PR TITLE
go.py 3.0.2: regexp search & cancel

### DIFF
--- a/python/go.py
+++ b/python/go.py
@@ -22,6 +22,8 @@
 #
 # History:
 #
+# 2025-10-17, Leo Vivier <zaeph@zaeph.net>:
+#     version 3.0.2: add regexp search and cancellation with scroll_bottom
 # 2024-05-30, Sébastien Helleu <flashcode@flashtux.org>:
 #     version 3.0.1: refresh buffer input at the end of search
 # 2024-05-30, Sébastien Helleu <flashcode@flashtux.org>:

--- a/python/go.py
+++ b/python/go.py
@@ -553,6 +553,10 @@ def go_command_run_buffer(data, buf, command):
 
 def go_command_run_window(data, buf, command):
     """Function called when a command "/window xxx" is run."""
+    if command == '/window scroll_bottom':
+        # cancel selection and return to input
+        go_end(buf)
+        return weechat.WEECHAT_RC_OK_EAT
     return weechat.WEECHAT_RC_OK_EAT
 
 

--- a/python/go.py
+++ b/python/go.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# Copyright (C) 2025 Leo Vivier <zaeph@zaeph.net>
 # Copyright (C) 2009-2023 Sébastien Helleu <flashcode@flashtux.org>
 # Copyright (C) 2010 m4v <lambdae2@gmail.com>
 # Copyright (C) 2011 stfn <stfnmd@googlemail.com>
@@ -148,6 +149,9 @@ SETTINGS = {
     'color_name_highlight_selected': (
         'red,brown',
         'color for highlight in a selected buffer name'),
+    'regexp_search': (
+        'off',
+        'search buffer matches using regexps'),
     'fuzzy_search': (
         'off',
         'search buffer matches using approximation'),
@@ -356,7 +360,10 @@ def go_matching_buffers(strinput):
             full_name = '%s.%s' % (
                 weechat.infolist_string(infolist, 'plugin_name'),
                 weechat.infolist_string(infolist, 'name'))
-        matching = name.lower().find(strinput) >= 0
+        if go_option_enabled('regexp_search'):
+            matching = bool(re.search(strinput, name, re.IGNORECASE))
+        else:
+            matching = name.lower().find(strinput) >= 0
         if not matching and strinput[-1] == ' ':
             matching = name.lower().endswith(strinput.strip())
         if not matching and go_option_enabled('fuzzy_search'):


### PR DESCRIPTION
## Script info

<!-- MANDATORY INFO: -->

- Script name: go.py
- Version: 3.0.2

## Description

Added 2 features:
- Regexp search (off by default)
- Cancel with `/window scroll_bottom` (there could be other nice cancellation to add, but this is the one that I use the most)

## Checklist (script update)

<!-- To fill only if you are updating an existing script -->

<!-- Please validate and check each item with "[x]" (see file CONTRIBUTING.md) -->

Haven't found a repo for the original script from the original author.  Changes are non-controversial.  I think @flashcode has taken over the maintenance.

- [ ] Author has been contacted
- [ ] Single commit, single file added
- [ ] Commit message format: `script_name.py X.Y: …`
- [ ] Script version and Changelog have been updated
- [X] For Python script: works with Python 3 (Python 2 support is optional)
- [ ] Score 100 / 100 displayed by [weechat-script-lint](https://github.com/weechat/weechat-script-lint)

First time contributor.  If commits need to be adjusted (e.g. squash and with version added), let me know and I can do the legwork.
