### PR TITLE
Fix urlselect.lua so it loads with stricter lua

### DIFF
--- a/lua/urlselect.lua
+++ b/lua/urlselect.lua
@@ -969,8 +969,8 @@ function cmd_action_run(buffer, args)
       if entry then
          set_status("Running cmd " .. (entry.label or args))
          for cmd in split(entry.command, ";") do
-            cmd = eval_current_entry(cmd)
-            w.command(buffer, cmd)
+            fixed_cmd = eval_current_entry(cmd)
+            w.command(buffer, fixed_cmd)
          end
       end
    end


### PR DESCRIPTION
## Script info

<!-- MANDATORY INFO: -->

- Script name:  urlselect.lua
- Version:  0.5 (no update, very minor change)

## Description

<!-- Describe the new script or your changes in a few sentences -->

Just changing a function so that it will load under the newer versions of weechat and lua found on Arch Linux.

<!-- To fill only if you are updating an existing script -->

<!-- Please validate and check each item with "[x]" (see file CONTRIBUTING.md) -->

- [ ] Author has been contacted
- [x] Single commit, single file added
- [ ] Commit message format: `script_name.py X.Y: …`
- [ ] Script version and Changelog have been updated
- [ ] For Python script: works with Python 3 (Python 2 support is optional)
- [ ] Score 100 / 100 displayed by [weechat-script-lint](https://github.com/weechat/weechat-script-lint)