### PR TITLE
fix: use raw string for glitter regex pattern

### DIFF
--- a/python/glitter.py
+++ b/python/glitter.py
@@ -9,7 +9,7 @@ SCRIPT_DESC    = "Replaces ***text*** you write with rainbow text"
 if weechat.register(SCRIPT_NAME, SCRIPT_AUTHOR, SCRIPT_VERSION, SCRIPT_LICENSE, SCRIPT_DESC, "", ""):
    weechat.hook_command_run("/input return", "command_run_input", "")
 
-glitter_pat = re.compile("\*\*\*([^\*]+)\*\*\*")
+glitter_pat = re.compile(r"\*\*\*([^*]+)\*\*\*")
 def glitter_it(match):
    lut = ("13","4","8","9","11","12") # len=6
    text = match.group(1)


### PR DESCRIPTION
Replace the regex pattern string with a raw string and remove unnecessary escaping of '*' in the character class.

This eliminates the warning emitted by newer python versions:

SyntaxWarning: "\*" is an invalid escape sequence. Such sequences will not work in the future.
Did you mean "\\*"?

The regex behavior is unchanged.
