### PR TITLE
shortenurl.py 0.6.7 : added shortener

### DIFF
--- a/python/shortenurl.py
+++ b/python/shortenurl.py
@@ -14,6 +14,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # History
+# 2026-07-16, CrazyCat <crazycat@c-p-f.org>
+#    version 0.6.7: Added zeolia as provider, since tinyurl as changed
+#    Key is mandatory to avoid bad usages of the system.
+#    Ask me a key by mail or on irc.zeolia.chat
 # 2019-10-10, CrazyCat <crazycat@c-p-f.org>
 #  version 0.6.6: fix trouble of "b'"
 #    : fix short_own=off bug when user is @,% or +
@@ -60,28 +64,31 @@ except ImportError:
 
 SCRIPT_NAME = "shortenurl"
 SCRIPT_AUTHOR = "John Anderson <sontek@gmail.com>"
-SCRIPT_VERSION = "0.6.6"
+SCRIPT_VERSION = "0.6.7"
 SCRIPT_LICENSE = "GPL3"
 SCRIPT_DESC = "Shorten long incoming and outgoing URLs"
 
 ISGD = 'https://is.gd/create.php?format=simple&%s'
 TINYURL = 'http://tinyurl.com/api-create.php?%s'
+ZEOLIA = 'https://s.zeolia.chat?%s';
 
 # script options
 # shortener options:
 #  - isgd
 #  - tinyurl
 #  - bitly
+#  - zeolia
 
 settings = {
     "color": "red",
     "urllength": "30",
     "shortener": "isgd",
     "short_own": "off",
-    "ignore_list": "http://is.gd,http://tinyurl.com,http://bit.ly",
+    "ignore_list": "http://is.gd,http://tinyurl.com,http://bit.ly,https://s.zeolia.chat",
     "bitly_login": "",
     "bitly_key": "",
-    "bitly_add_to_history": "true"
+    "bitly_add_to_history": "true",
+    "zeolia_key": ""
 }
 
 octet = r'(?:2(?:[0-4]\d|5[0-5])|1\d\d|\d{1,2})'
@@ -162,6 +169,9 @@ def get_shortened_url(url):
         url = ISGD % urlencode({'url': url})
     if shortener == 'tinyurl':
         url = TINYURL % urlencode({'url': url})
+    if shortener == 'zeolia':
+         apikey = weechat.config_get_plugin('zeolia_key')
+         url = ZEOLIA % urlencode({'key': apikey, 'q': url})
     try:
         opener = build_opener()
         opener.addheaders = [('User-Agent', 'weechat')]


### PR DESCRIPTION
Old shorteners have changed, so I created mine, designated for a weechat usage. Actually in beta-test, I'll probably change the error management to return the original url if there is any trouble. It needs a personnal key, I will provide them by mail, ask me on ircs://irc.zeolia.chat/anobug

## Script info

<!-- MANDATORY INFO: -->

- Script name: shortenurl.py
- Version: 0.6.7

## Description

Old shorteners have changed, so I created mine, designated for a weechat usage.
Actually in beta-test, I'll probably change the error management to return the original url if there is any trouble.
It needs a personnal key, I will provide them by mail, ask me on ircs://irc.zeolia.chat/anobug

## Checklist (script update)

<!-- To fill only if you are updating an existing script -->

<!-- Please validate and check each item with "[x]" (see file CONTRIBUTING.md) -->

- [ ] Author has been contacted
- [x] Single commit, single file added
- [x] Commit message format: `script_name.py X.Y: …`
- [x] Script version and Changelog have been updated
- [x] For Python script: works with Python 3 (Python 2 support is optional)
- [ ] Score 100 / 100 displayed by [weechat-script-lint](https://github.com/weechat/weechat-script-lint)
