### PR TITLE
New script emphasys.tcl: simply add bold and italic

### DIFF
--- a/tcl/emphasys
+++ b/tcl/emphasys
@@ -1,0 +1,26 @@
+#
+# SPDFX-FileCopyrightText: 2026 CrazyCat <crazycat@c-p-f.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set SCRIPT_NAME "emphasys"
+set SCRIPT_AUTHOR "CrazyCat <crazycat@c-p-f.org>"
+set SCRIPT_VERSION "1.0"
+set SCRIPT_LICENSE "GPL3"
+set SCRIPT_DESC "Replaces *text* whith bold and /text/ with italic (or reverse)"
+
+::weechat::register $SCRIPT_NAME $SCRIPT_AUTHOR $SCRIPT_VERSION $SCRIPT_LICENSE $SCRIPT_DESC {} {}
+::weechat::hook_modifier irc_out1_privmsg cmd_emphasys {}
+
+set rebold {\*(.+)\*}
+set reital {\/(.+)\/}
+
+proc cmd_emphasys {data modifier modifier_data irc_msg} {
+   set parts [split $irc_msg {:}]
+   set input [lindex $parts end]
+   regsub -all -- $::rebold $input "\002\\1\002" input
+   regsub -all -- $::reital $input "\026\\1\026" input
+   return [join [lreplace $parts end end $input] {:}]
+   return $::weechat::WEECHAT_RC_OK
+}


### PR DESCRIPTION
Replaces *text* whith bold and /text/ with italic (or reverse)

## Script info

- Script name:  emphasys
- Version:  1.0

- Script tags: input, tcl, channel, color

## Description

Replaces *text* whith bold and /text/ with italic (or reverse)

## Checklist (new script)

- [x] Single commit, single file added
- [x] Commit message: `New script name.py: short description…`
- [x] No similar script already exists
- [x] Name: max 32 chars, only lower case letters, digits and underscores
- [x] Unique name, does not already exist in repository
- [x] No shebang on the first line
- [x] Comment in script with name/pseudo, e-mail and license using [SPDX](https://spdx.dev/) tags (see [Contributing guide](https://github.com/weechat/scripts/blob/main/CONTRIBUTING.md#copyright-and-license))
- [x] Only English in code/comments
- [x] Pure WeeChat API used, no extra API
- [ ] Score 100 / 100 displayed by [weechat-script-lint](https://github.com/weechat/weechat-script-lint)

