### PR TITLE
New script emphasys.tcl : quick way to use bold and italic/reverse

### DIFF
--- a/tcl/emphasys
+++ b/tcl/emphasys
@@ -1,0 +1,26 @@
+#
+# SPDFX-FileCopyrightText: 2026 CrazyCat <crazycat@c-p-f.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set SCRIPT_NAME "emphasys"
+set SCRIPT_AUTHOR "CrazyCat <crazycat@c-p-f.org>"
+set SCRIPT_VERSION "1.0"
+set SCRIPT_LICENSE "GPL3"
+set SCRIPT_DESC "Replaces *text* whith bold and /text/ with italic (or reverse)"
+
+::weechat::register $SCRIPT_NAME $SCRIPT_AUTHOR $SCRIPT_VERSION $SCRIPT_LICENSE $SCRIPT_DESC {} {}
+::weechat::hook_modifier irc_out1_privmsg cmd_emphasys {}
+
+set rebold {\*(.+)\*}
+set reital {\/(.+)\/}
+
+proc cmd_emphasys {data modifier modifier_data irc_msg} {
+   set parts [split $irc_msg {:}]
+   set input [lindex $parts end]
+   regsub -all -- $::rebold $input "\002\\1\002" input
+   regsub -all -- $::reital $input "\026\\1\026" input
+   return [join [lreplace $parts end end $input] {:}]
+   return $::weechat::WEECHAT_RC_OK
+}

--- a/tcl/emphasys.tcl
+++ b/tcl/emphasys.tcl
@@ -13,14 +13,14 @@ set SCRIPT_DESC "Replaces *text* whith bold and /text/ with italic (or reverse)"
 ::weechat::register $SCRIPT_NAME $SCRIPT_AUTHOR $SCRIPT_VERSION $SCRIPT_LICENSE $SCRIPT_DESC {} {}
 ::weechat::hook_modifier irc_out1_privmsg cmd_emphasys {}
 
-set rebold {\s\*(.+)\*\s}
-set reital {\s\/(.+)\/\s}
+set rebold {(\s)\*(.+)\*(\s)}
+set reital {(\s)\/(.+)\/(\s)}
 
 proc cmd_emphasys {data modifier modifier_data irc_msg} {
    set parts [split $irc_msg {:}]
    set input [lindex $parts end]
-   regsub -all -- $::rebold $input "\002\\1\002" input
-   regsub -all -- $::reital $input "\026\\1\026" input
+   regsub -all -- $::rebold $input "\\1\002\\2\002\\3" input
+   regsub -all -- $::reital $input "\\1\026\\2\026\\3" input
    return [join [lreplace $parts end end $input] {:}]
    return $::weechat::WEECHAT_RC_OK
 }

--- a/tcl/emphasys.tcl
+++ b/tcl/emphasys.tcl
@@ -1,5 +1,5 @@
 #
-# SPDFX-FileCopyrightText: 2026 CrazyCat <crazycat@c-p-f.org>
+# SPDX-FileCopyrightText: 2026 CrazyCat <crazycat@c-p-f.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/tcl/emphasys.tcl
+++ b/tcl/emphasys.tcl
@@ -13,12 +13,12 @@ set SCRIPT_DESC "Replaces *text* whith bold and /text/ with italic (or reverse)"
 ::weechat::register $SCRIPT_NAME $SCRIPT_AUTHOR $SCRIPT_VERSION $SCRIPT_LICENSE $SCRIPT_DESC {} {}
 ::weechat::hook_modifier irc_out1_privmsg cmd_emphasys {}
 
-set rebold {(\s)\*(.+)\*(\s)}
-set reital {(\s)\/(.+)\/(\s)}
+set rebold {(\s)\*(.+?)\*(\s)}
+set reital {(\s)\/(.+?)\/(\s)}
 
 proc cmd_emphasys {data modifier modifier_data irc_msg} {
    set parts [split $irc_msg {:}]
-   set input [lindex $parts end]
+   set input [join [lrange $parts 1 end] {:}]
    regsub -all -- $::rebold $input "\\1\002\\2\002\\3" input
    regsub -all -- $::reital $input "\\1\026\\2\026\\3" input
    return [join [lreplace $parts end end $input] {:}]

--- a/tcl/emphasys.tcl
+++ b/tcl/emphasys.tcl
@@ -13,8 +13,8 @@ set SCRIPT_DESC "Replaces *text* whith bold and /text/ with italic (or reverse)"
 ::weechat::register $SCRIPT_NAME $SCRIPT_AUTHOR $SCRIPT_VERSION $SCRIPT_LICENSE $SCRIPT_DESC {} {}
 ::weechat::hook_modifier irc_out1_privmsg cmd_emphasys {}
 
-set rebold {\*(.+)\*}
-set reital {\/(.+)\/}
+set rebold {\s\*(.+)\*\s}
+set reital {\s\/(.+)\/\s}
 
 proc cmd_emphasys {data modifier modifier_data irc_msg} {
    set parts [split $irc_msg {:}]

--- a/tcl/emphasys.tcl
+++ b/tcl/emphasys.tcl
@@ -8,13 +8,13 @@ set SCRIPT_NAME "emphasys"
 set SCRIPT_AUTHOR "CrazyCat <crazycat@c-p-f.org>"
 set SCRIPT_VERSION "1.0"
 set SCRIPT_LICENSE "GPL3"
-set SCRIPT_DESC "Replaces *text* whith bold and /text/ with italic (or reverse)"
+set SCRIPT_DESC "Replaces *text* whith bold and /text/ with italic (or reverse) in IRC messages (channels and privates)"
 
 ::weechat::register $SCRIPT_NAME $SCRIPT_AUTHOR $SCRIPT_VERSION $SCRIPT_LICENSE $SCRIPT_DESC {} {}
 ::weechat::hook_modifier irc_out1_privmsg cmd_emphasys {}
 
-set rebold {(\s)\*(.+?)\*(\s)}
-set reital {(\s)\/(.+?)\/(\s)}
+set rebold {(^|\s)\*(.+?)\*(\s|$)}
+set reital {(^|\s)\/(.+?)\/(\s|$)}
 
 proc cmd_emphasys {data modifier modifier_data irc_msg} {
    set parts [split $irc_msg {:}]


### PR DESCRIPTION
## Script info

<!-- MANDATORY INFO: -->

- Script name:  emphasys.tcl
- Version:  1.0

<!-- Optional: tags for script (see list of tags on https://weechat.org/scripts/), new tags are allowed -->
- Script tags: colors, channel, tcl

## Description

Replaces `*text*` with bold and `/text/` with italic (or reverse)

## Checklist (new script)

<!-- To fill only if you are adding a new script -->

<!-- Please validate and check each item with "[x]" (see file CONTRIBUTING.md) -->

- [x] Single commit, single file added
- [x] Commit message: `New script name.py: short description…`
- [x] No similar script already exists
- [x] Name: max 32 chars, only lower case letters, digits and underscores
- [x] Unique name, does not already exist in repository
- [x] No shebang on the first line
- [x] Comment in script with name/pseudo, e-mail and license using [SPDX](https://spdx.dev/) tags (see [Contributing guide](https://github.com/weechat/scripts/blob/main/CONTRIBUTING.md#copyright-and-license))
- [x] Only English in code/comments
- [x] Pure WeeChat API used, no extra API
- [x] Function `hook_url`, `hook_process` or `hook_process_hashtable` is used for any blocking call
- [x] For Python script: works with Python 3 (Python 2 support is optional)
- [x] Score 100 / 100 displayed by [weechat-script-lint](https://github.com/weechat/weechat-script-lint)

