### PR TITLE
sysinfo.pl 1.2.3: fix memory used/free swapped in display and percent

### DIFF
--- a/perl/sysinfo.pl
+++ b/perl/sysinfo.pl
@@ -39,6 +39,10 @@
 #
 # ported to WeeChat (http://www.weechat.org/) by Nils Görs.
 #
+# 2026-09-05: 1.2.3 TehPeGaSuS <pegasus@computer4u.com>
+#           : fix: memoryusage() showed free memory mislabeled as used, and
+#             the percentage could go negative, because the used/free values
+#             were swapped in the final display/percent calculation
 # 2026-09-05: 1.2.2 TehPeGaSuS <pegasus@computer4u.com>
 #           : fix: memory usage broken (uninitialized values / division by 0,
 #             closes #581) on kernel >= 6.x due to kernel version regex only
@@ -83,7 +87,7 @@ use POSIX qw(floor);
 use strict;
 
 my $SCRIPT_NAME         = "sysinfo";
-my $SCRIPT_VERSION      = "1.2.2";
+my $SCRIPT_VERSION      = "1.2.3";
 my $SCRIPT_DESCR        = "provides a system info command";
 my $SCRIPT_LICENSE      = "BSD-2-Clause";
 my $SCRIPT_AUTHOR       = "Nils Görs <weechatter\@arcor.de>";
@@ -884,8 +888,8 @@ sub memoryusage {
 		$vard = `vmstat -s | grep 'pages active' | awk '{print \$1}'` * `vmstat -s | grep 'per page' | awk '{print \$1}'`;
 		$vara = `$sysctl -n hw.physmem`;
 	}
-	$varp = sprintf("%.2f", 100-($vard / ($vara-$vard) * 100));
-	return human_size($vara-$vard)."/".human_size($vara)." ($varp%)";
+	$varp = sprintf("%.2f", ($vard / $vara) * 100);
+	return human_size($vard)."/".human_size($vara)." ($varp%)";
 }
 
 sub networkinfobsd {


### PR DESCRIPTION
`memoryusage()` computes `$vard` as the actual used memory (`Total - Free - Buffers - Cached`), but the final return statement treats it as if it were free memory instead:

```perl
$varp = sprintf("%.2f", 100-($vard / ($vara-$vard) * 100));
return human_size($vara-$vard)."/".human_size($vara)." ($varp%)";
```

This mislabels free memory as used in the displayed output, and can produce a negative percentage whenever used memory exceeds free memory, e.g.:

```
Memory Usage: 2.83GB/7.57GB (-67.52%)
```

(on a host where 4.74GB was actually in use, i.e. ~62.6%).

Fix by using $vard directly for both the display and the percentage:

```perl
$varp = sprintf("%.2f", ($vard / $vara) * 100);
return human_size($vard)."/".human_size($vara)." ($varp%)";
```

This follows up #610 (merged as 1.2.2), which fixed the kernel-version detection but left this separate used/free swap in place.